### PR TITLE
Barrier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ fn main() {
     // 5. Decide of a cutoff heuristic (if you dont want to let the solver run for ever)
     let cutoff = NoCutoff; // might as well be a TimeBudget (or something else)
 
-    // 5. Create the solver frontier
-    let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+    // 5. Create the solver fringe
+    let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
     
     // 6. Instanciate your solver
     let mut solver = DefaultSolver::new(
@@ -244,7 +244,7 @@ fn main() {
           &heuristic, 
           &width, 
           &cutoff, 
-          &mut frontier);
+          &mut fringe);
 
     // 7. Maximize your objective function
     // the outcome provides the value of the best solution that was found for

--- a/ddo/examples/knapsack/main.rs
+++ b/ddo/examples/knapsack/main.rs
@@ -266,7 +266,7 @@ fn main() {
     let heuristic= KPranking;
     let width = max_width(problem.nb_variables(), args.width);
     let cutoff = TimeBudget::new(Duration::from_secs(15));//NoCutoff;
-    let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+    let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -274,7 +274,7 @@ fn main() {
         &heuristic, 
         width.as_ref(), 
         &cutoff, 
-        &mut frontier);
+        &mut fringe);
 
     let start = Instant::now();
     let Completion{ is_exact, best_value } = solver.maximize();

--- a/ddo/examples/knapsack/main.rs
+++ b/ddo/examples/knapsack/main.rs
@@ -267,7 +267,7 @@ fn main() {
     let width = max_width(problem.nb_variables(), args.width);
     let cutoff = TimeBudget::new(Duration::from_secs(15));//NoCutoff;
     let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -276,7 +276,7 @@ fn main() {
         width.as_ref(), 
         &cutoff, 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
     let start = Instant::now();

--- a/ddo/examples/knapsack/main.rs
+++ b/ddo/examples/knapsack/main.rs
@@ -267,6 +267,7 @@ fn main() {
     let width = max_width(problem.nb_variables(), args.width);
     let cutoff = TimeBudget::new(Duration::from_secs(15));//NoCutoff;
     let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
+    let mut barrier = EmptyBarrier{};
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -274,7 +275,9 @@ fn main() {
         &heuristic, 
         width.as_ref(), 
         &cutoff, 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
     let start = Instant::now();
     let Completion{ is_exact, best_value } = solver.maximize();

--- a/ddo/examples/knapsack/tests.rs
+++ b/ddo/examples/knapsack/tests.rs
@@ -43,7 +43,7 @@ pub fn solve_id(id: &str) -> isize {
 
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(

--- a/ddo/examples/knapsack/tests.rs
+++ b/ddo/examples/knapsack/tests.rs
@@ -44,6 +44,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+    let mut barrier = EmptyBarrier{};
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -52,7 +53,9 @@ pub fn solve_id(id: &str) -> isize {
         &ranking, 
         &width, 
         &cutoff, 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
     let Completion { best_value , ..} = solver.maximize();
     best_value.map(|x| x).unwrap_or(-1)

--- a/ddo/examples/knapsack/tests.rs
+++ b/ddo/examples/knapsack/tests.rs
@@ -44,7 +44,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -54,7 +54,7 @@ pub fn solve_id(id: &str) -> isize {
         &width, 
         &cutoff, 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
     let Completion { best_value , ..} = solver.maximize();

--- a/ddo/examples/max2sat/main.rs
+++ b/ddo/examples/max2sat/main.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use ddo::{TimeBudget, NoCutoff, Cutoff, FixedWidth, DefaultSolver, NoDupFrontier, MaxUB, Solver, Completion, WidthHeuristic, NbUnassignedWitdh, Problem, Decision, Variable};
+use ddo::{TimeBudget, NoCutoff, Cutoff, FixedWidth, DefaultSolver, NoDupFringe, MaxUB, Solver, Completion, WidthHeuristic, NbUnassignedWitdh, Problem, Decision, Variable};
 use model::{f, t};
 
 use crate::{heuristics::Max2SatRanking, model::{Max2Sat, v}, relax::Max2SatRelax, data::read_instance};
@@ -36,7 +36,7 @@ fn main() {
     let rank = Max2SatRanking;
     let width = max_width(&problem, width);
     let cutoff = cutoff(timeout);
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&Max2SatRanking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&Max2SatRanking));
 
     let mut solver = DefaultSolver::new(
         &problem, 

--- a/ddo/examples/max2sat/main.rs
+++ b/ddo/examples/max2sat/main.rs
@@ -37,7 +37,7 @@ fn main() {
     let width = max_width(&problem, width);
     let cutoff = cutoff(timeout);
     let mut fringe = NoDupFringe::new(MaxUB::new(&Max2SatRanking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -46,7 +46,7 @@ fn main() {
         width.as_ref(), 
         cutoff.as_ref(), 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
         let start = Instant::now();

--- a/ddo/examples/max2sat/main.rs
+++ b/ddo/examples/max2sat/main.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use ddo::{TimeBudget, NoCutoff, Cutoff, FixedWidth, DefaultSolver, NoDupFringe, MaxUB, Solver, Completion, WidthHeuristic, NbUnassignedWitdh, Problem, Decision, Variable};
+use ddo::{TimeBudget, NoCutoff, Cutoff, FixedWidth, DefaultSolver, NoDupFringe, MaxUB, Solver, Completion, WidthHeuristic, NbUnassignedWitdh, Problem, Decision, Variable, EmptyBarrier};
 use model::{f, t};
 
 use crate::{heuristics::Max2SatRanking, model::{Max2Sat, v}, relax::Max2SatRelax, data::read_instance};
@@ -37,6 +37,7 @@ fn main() {
     let width = max_width(&problem, width);
     let cutoff = cutoff(timeout);
     let mut fringe = NoDupFringe::new(MaxUB::new(&Max2SatRanking));
+    let mut barrier = EmptyBarrier{};
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -44,7 +45,9 @@ fn main() {
         &rank, 
         width.as_ref(), 
         cutoff.as_ref(), 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
         let start = Instant::now();
         let Completion{ is_exact, best_value } = solver.maximize();

--- a/ddo/examples/max2sat/tests.rs
+++ b/ddo/examples/max2sat/tests.rs
@@ -43,7 +43,7 @@ pub fn solve_id(id: &str) -> isize {
 
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(

--- a/ddo/examples/max2sat/tests.rs
+++ b/ddo/examples/max2sat/tests.rs
@@ -44,6 +44,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+    let mut barrier = EmptyBarrier{};
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -52,7 +53,9 @@ pub fn solve_id(id: &str) -> isize {
         &ranking, 
         &width, 
         &cutoff, 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
     let Completion { best_value , ..} = solver.maximize();
     best_value.map(|x| x).unwrap_or(-1)

--- a/ddo/examples/max2sat/tests.rs
+++ b/ddo/examples/max2sat/tests.rs
@@ -44,7 +44,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -54,7 +54,7 @@ pub fn solve_id(id: &str) -> isize {
         &width, 
         &cutoff, 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
     let Completion { best_value , ..} = solver.maximize();

--- a/ddo/examples/mcp/main.rs
+++ b/ddo/examples/mcp/main.rs
@@ -35,7 +35,7 @@ fn main() {
     let width = max_width(&problem, width);
     let cutoff = cutoff(timeout);
     let mut fringe = NoDupFringe::new(MaxUB::new(&rank));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -44,7 +44,7 @@ fn main() {
         width.as_ref(), 
         cutoff.as_ref(), 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
         let start = Instant::now();

--- a/ddo/examples/mcp/main.rs
+++ b/ddo/examples/mcp/main.rs
@@ -35,6 +35,7 @@ fn main() {
     let width = max_width(&problem, width);
     let cutoff = cutoff(timeout);
     let mut fringe = NoDupFringe::new(MaxUB::new(&rank));
+    let mut barrier = EmptyBarrier{};
 
     let mut solver = DefaultSolver::new(
         &problem, 
@@ -42,7 +43,9 @@ fn main() {
         &rank, 
         width.as_ref(), 
         cutoff.as_ref(), 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
         let start = Instant::now();
         let Completion{ is_exact, best_value } = solver.maximize();

--- a/ddo/examples/mcp/main.rs
+++ b/ddo/examples/mcp/main.rs
@@ -34,7 +34,7 @@ fn main() {
     let rank = McpRanking;
     let width = max_width(&problem, width);
     let cutoff = cutoff(timeout);
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&rank));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&rank));
 
     let mut solver = DefaultSolver::new(
         &problem, 

--- a/ddo/examples/mcp/tests.rs
+++ b/ddo/examples/mcp/tests.rs
@@ -46,7 +46,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -56,7 +56,7 @@ pub fn solve_id(id: &str) -> isize {
         &width, 
         &cutoff, 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
     let Completion { best_value , ..} = solver.maximize();

--- a/ddo/examples/mcp/tests.rs
+++ b/ddo/examples/mcp/tests.rs
@@ -45,7 +45,7 @@ pub fn solve_id(id: &str) -> isize {
 
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(

--- a/ddo/examples/mcp/tests.rs
+++ b/ddo/examples/mcp/tests.rs
@@ -46,6 +46,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+    let mut barrier = EmptyBarrier{};
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -54,7 +55,9 @@ pub fn solve_id(id: &str) -> isize {
         &ranking, 
         &width, 
         &cutoff, 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
     let Completion { best_value , ..} = solver.maximize();
     best_value.map(|x| x).unwrap_or(-1)

--- a/ddo/examples/misp/main.rs
+++ b/ddo/examples/misp/main.rs
@@ -349,6 +349,7 @@ fn main() {
     let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+    let mut barrier = EmptyBarrier{};
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::<BitSet, DefaultMDD<BitSet>>::custom(
@@ -359,6 +360,7 @@ fn main() {
         cutset,
         cutoff.as_ref(), 
         &mut fringe,
+        &mut barrier,
         args.threads,
     );
 

--- a/ddo/examples/misp/main.rs
+++ b/ddo/examples/misp/main.rs
@@ -337,7 +337,7 @@ fn cutoff(timeout: Option<u64>) -> Box<dyn Cutoff + Send + Sync> {
 }
 
 /// This is your executable's entry point. It is the place where all the pieces are put together
-/// to create a fast an effective solver for the knapsack problem.
+/// to create a fast an effective solver for the misp problem.
 fn main() {
     let args = Args::parse();
     let fname = &args.fname;
@@ -346,6 +346,7 @@ fn main() {
     let ranking = MispRanking;
 
     let width = max_width(&problem, args.width);
+    let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
     let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
 
@@ -354,10 +355,12 @@ fn main() {
         &problem, 
         &relaxation, 
         &ranking, 
-        width.as_ref(), 
+        width.as_ref(),
+        cutset,
         cutoff.as_ref(), 
         &mut fringe,
-        args.threads);
+        args.threads,
+    );
 
     let start = Instant::now();
     let Completion{ is_exact, best_value } = solver.maximize();

--- a/ddo/examples/misp/main.rs
+++ b/ddo/examples/misp/main.rs
@@ -349,7 +349,7 @@ fn main() {
     let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::<BitSet, DefaultMDD<BitSet>>::custom(
@@ -360,7 +360,7 @@ fn main() {
         cutset,
         cutoff.as_ref(), 
         &mut fringe,
-        &mut barrier,
+        &barrier,
         args.threads,
     );
 

--- a/ddo/examples/misp/main.rs
+++ b/ddo/examples/misp/main.rs
@@ -348,7 +348,7 @@ fn main() {
     let width = max_width(&problem, args.width);
     let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::<BitSet, DefaultMDD<BitSet>>::custom(

--- a/ddo/examples/misp/tests.rs
+++ b/ddo/examples/misp/tests.rs
@@ -44,7 +44,7 @@ pub fn solve_id(id: &str) -> isize {
 
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(

--- a/ddo/examples/misp/tests.rs
+++ b/ddo/examples/misp/tests.rs
@@ -45,6 +45,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+    let mut barrier = EmptyBarrier{};
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -53,7 +54,9 @@ pub fn solve_id(id: &str) -> isize {
         &ranking, 
         &width, 
         &cutoff, 
-        &mut fringe);
+        &mut fringe,
+        &mut barrier,
+    );
 
     let Completion { best_value , ..} = solver.maximize();
     best_value.map(|x| x).unwrap_or(-1)

--- a/ddo/examples/misp/tests.rs
+++ b/ddo/examples/misp/tests.rs
@@ -45,7 +45,7 @@ pub fn solve_id(id: &str) -> isize {
     let width = NbUnassignedWitdh(problem.nb_variables());
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::new(
@@ -55,7 +55,7 @@ pub fn solve_id(id: &str) -> isize {
         &width, 
         &cutoff, 
         &mut fringe,
-        &mut barrier,
+        &barrier,
     );
 
     let Completion { best_value , ..} = solver.maximize();

--- a/ddo/examples/psp/main.rs
+++ b/ddo/examples/psp/main.rs
@@ -95,6 +95,7 @@ fn main() {
     let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+    let mut barrier = EmptyBarrier{};
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::<PspState, DefaultMDD<PspState>>::custom(
@@ -105,6 +106,7 @@ fn main() {
         cutset,
         cutoff.as_ref(), 
         &mut fringe,
+        &mut barrier,
         args.threads,
     );
 

--- a/ddo/examples/psp/main.rs
+++ b/ddo/examples/psp/main.rs
@@ -94,7 +94,7 @@ fn main() {
     let width = max_width(&problem, args.width);
     let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
-    let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+    let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::<PspState, DefaultMDD<PspState>>::custom(

--- a/ddo/examples/psp/main.rs
+++ b/ddo/examples/psp/main.rs
@@ -92,6 +92,7 @@ fn main() {
     let ranking = PspRanking;
 
     let width = max_width(&problem, args.width);
+    let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
     let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
 
@@ -101,9 +102,11 @@ fn main() {
         &relaxation, 
         &ranking, 
         width.as_ref(), 
+        cutset,
         cutoff.as_ref(), 
         &mut fringe,
-        args.threads);
+        args.threads,
+    );
 
     let start = Instant::now();
     let Completion{ is_exact, best_value } = solver.maximize();

--- a/ddo/examples/psp/main.rs
+++ b/ddo/examples/psp/main.rs
@@ -95,7 +95,7 @@ fn main() {
     let cutset = CutsetType::LastExactLayer;
     let cutoff = cutoff(args.duration);
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-    let mut barrier = EmptyBarrier{};
+    let barrier = EmptyBarrier::new();
 
     // This solver compile DD that allow the definition of long arcs spanning over several layers.
     let mut solver = DefaultSolver::<PspState, DefaultMDD<PspState>>::custom(
@@ -106,7 +106,7 @@ fn main() {
         cutset,
         cutoff.as_ref(), 
         &mut fringe,
-        &mut barrier,
+        &barrier,
         args.threads,
     );
 

--- a/ddo/examples/psp/tests.rs
+++ b/ddo/examples/psp/tests.rs
@@ -46,7 +46,7 @@ mod psp_test_utils {
         let cutset = CutsetType::LastExactLayer;
         let cutoff = NoCutoff;
         let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
-        let mut barrier = EmptyBarrier{};
+        let barrier = EmptyBarrier::new();
 
         // This solver compile DD that allow the definition of long arcs spanning over several layers.
         let mut solver = DefaultSolver::<PspState, DefaultMDD<PspState>>::custom(
@@ -57,7 +57,7 @@ mod psp_test_utils {
             cutset,
             &cutoff, 
             &mut fringe,
-            &mut barrier,
+            &barrier,
             1,
         );
 

--- a/ddo/examples/psp/tests.rs
+++ b/ddo/examples/psp/tests.rs
@@ -45,7 +45,7 @@ mod psp_test_utils {
         let width = FixedWidth(1000);
         let cutset = CutsetType::LastExactLayer;
         let cutoff = NoCutoff;
-        let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
 
         // This solver compile DD that allow the definition of long arcs spanning over several layers.
         let mut solver = DefaultSolver::<PspState, DefaultMDD<PspState>>::custom(

--- a/ddo/examples/psp/tests.rs
+++ b/ddo/examples/psp/tests.rs
@@ -43,6 +43,7 @@ mod psp_test_utils {
         let ranking = PspRanking;
 
         let width = FixedWidth(1000);
+        let cutset = CutsetType::LastExactLayer;
         let cutoff = NoCutoff;
         let mut fringe = NoDupFrontier::new(MaxUB::new(&ranking));
 
@@ -52,9 +53,11 @@ mod psp_test_utils {
             &relaxation, 
             &ranking, 
             &width, 
+            cutset,
             &cutoff, 
             &mut fringe,
-            1);
+            1,
+        );
 
         let Completion { best_value , ..} = solver.maximize();
         best_value.map(|x| -x).unwrap_or(-1)

--- a/ddo/examples/psp/tests.rs
+++ b/ddo/examples/psp/tests.rs
@@ -46,6 +46,7 @@ mod psp_test_utils {
         let cutset = CutsetType::LastExactLayer;
         let cutoff = NoCutoff;
         let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));
+        let mut barrier = EmptyBarrier{};
 
         // This solver compile DD that allow the definition of long arcs spanning over several layers.
         let mut solver = DefaultSolver::<PspState, DefaultMDD<PspState>>::custom(
@@ -56,6 +57,7 @@ mod psp_test_utils {
             cutset,
             &cutoff, 
             &mut fringe,
+            &mut barrier,
             1,
         );
 

--- a/ddo/src/abstraction/barrier.rs
+++ b/ddo/src/abstraction/barrier.rs
@@ -24,16 +24,6 @@
 //! `Relaxation` are defined. These are the two abstractions that one *must*
 //! implement in order to be able to use our library.
 
-mod dp;
-mod heuristics;
-mod solver;
-mod fringe;
-mod mdd;
-mod barrier;
-
-pub use dp::*;
-pub use heuristics::*;
-pub use solver::*;
-pub use fringe::*;
-pub use mdd::*;
-pub use barrier::*;
+pub trait Barrier {
+    
+}

--- a/ddo/src/abstraction/fringe.rs
+++ b/ddo/src/abstraction/fringe.rs
@@ -17,10 +17,29 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! This module provides several alternative implementation of the solver frontier.
+use crate::SubProblem;
 
-mod simple;
-mod no_duplicate;
 
-pub use simple::*;
-pub use no_duplicate::*;
+/// This trait abstracts away the implementation details of the solver fringe.
+/// That is, a Fringe represents the global priority queue which stores all 
+/// the nodes remaining to explore.
+pub trait Fringe {
+    type State;
+
+    /// This is how you push a node onto the fringe.
+    fn push(&mut self, node: SubProblem<Self::State>);
+    /// This method yields the most promising node from the fringe.
+    /// # Note:
+    /// The solvers rely on the assumption that a fringe will pop nodes in
+    /// descending upper bound order. Hence, it is a requirement for any fringe
+    /// implementation to enforce that requirement.
+    fn pop(&mut self) -> Option<SubProblem<Self::State>>;
+    /// This method clears the fringe: it removes all nodes from the queue.
+    fn clear(&mut self);
+    /// Yields the length of the queue.
+    fn len(&self) -> usize;
+    /// Returns true iff the fringe is empty (len == 0)
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/ddo/src/abstraction/heuristics.rs
+++ b/ddo/src/abstraction/heuristics.rs
@@ -82,9 +82,9 @@ pub trait StateRanking {
 }
 
 /// A subproblem ranking is an heuristic that imposes a partial order on
-/// subproblems on the solver frontier. This order is used by the framework 
+/// subproblems on the solver fringe. This order is used by the framework 
 /// as a means to impose a given ordering on the nodes that are popped from
-/// the solver frontier.
+/// the solver fringe.
 pub trait SubProblemRanking {
     /// As is the case for `Problem` and `Relaxation`, a `SubProblemRanking` 
     /// must tell the kind of states it is able to operate on.

--- a/ddo/src/abstraction/mdd.rs
+++ b/ddo/src/abstraction/mdd.rs
@@ -17,7 +17,9 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::{SubProblem, Completion, Reason, Problem, Relaxation, StateRanking, Solution, Cutoff};
+use std::sync::Arc;
+
+use crate::{SubProblem, Completion, Reason, Problem, Relaxation, StateRanking, Solution, Cutoff, Barrier};
 
 /// What type of cutset are we using for relaxed DDs ?
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,6 +59,8 @@ pub struct CompilationInput<'a, State> {
     pub residual: SubProblem<State>,
     /// The best known lower bound at the time when the dd is being compiled
     pub best_lb: isize,
+    /// Data structure containing info about past compilations used to prune the search
+    pub barrier: Arc<&'a mut (dyn Barrier + Send + Sync)>,
 }
 
 /// This trait describes the operations that can be expected from an abstract

--- a/ddo/src/abstraction/mdd.rs
+++ b/ddo/src/abstraction/mdd.rs
@@ -17,8 +17,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::sync::Arc;
-
 use crate::{SubProblem, Completion, Reason, Problem, Relaxation, StateRanking, Solution, Cutoff, Barrier};
 
 /// What type of cutset are we using for relaxed DDs ?
@@ -60,7 +58,7 @@ pub struct CompilationInput<'a, State> {
     /// The best known lower bound at the time when the dd is being compiled
     pub best_lb: isize,
     /// Data structure containing info about past compilations used to prune the search
-    pub barrier: Arc<&'a mut (dyn Barrier + Send + Sync)>,
+    pub barrier: &'a dyn Barrier<State = State>,
 }
 
 /// This trait describes the operations that can be expected from an abstract

--- a/ddo/src/abstraction/mdd.rs
+++ b/ddo/src/abstraction/mdd.rs
@@ -19,13 +19,22 @@
 
 use crate::{SubProblem, Completion, Reason, Problem, Relaxation, StateRanking, Solution, Cutoff};
 
+/// What type of cutset are we using for relaxed DDs ?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CutsetType {
+    /// enqueue the last layer with only exact nodes
+    LastExactLayer,
+    /// enqueue all exact nodes that have at least a relaxed child node
+    Frontier,
+}
+
 /// How are we to compile the decision diagram ? 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompilationType {
     /// If you want to use a pure DP resolution of the problem
     Exact,
     /// If you want to compile a restricted DD which yields a lower bound on the objective
-    Relaxed,
+    Relaxed(CutsetType),
     /// If you want to compile a relaxed DD which yields an upper bound on the objective
     Restricted,
 }

--- a/ddo/src/abstraction/mod.rs
+++ b/ddo/src/abstraction/mod.rs
@@ -27,11 +27,11 @@
 mod dp;
 mod heuristics;
 mod solver;
-mod frontier;
+mod fringe;
 mod mdd;
 
 pub use dp::*;
 pub use heuristics::*;
 pub use solver::*;
-pub use frontier::*;
+pub use fringe::*;
 pub use mdd::*;

--- a/ddo/src/common.rs
+++ b/ddo/src/common.rs
@@ -82,6 +82,8 @@ pub struct SubProblem<T> {
     pub path: Vec<Decision>,
     /// An upper bound on the objective reachable in this subproblem
     pub ub: isize,
+    /// The depth of the subproblem with respect to the root problem
+    pub depth: usize,
 }
 
 // ----------------------------------------------------------------------------
@@ -90,9 +92,11 @@ pub struct SubProblem<T> {
 /// A threshold is a value that can be stored during the execution of a branch
 /// and bound algorithm. It is associated with a single exact state and is used
 /// to determine whether a new node with the same state is worth exploring.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Threshold {
-    pub theta: isize,
+    /// The value of the threshold
+    pub value: isize,
+    /// Whether a node with the given value has already been explored
     pub explored: bool,
 }
 

--- a/ddo/src/common.rs
+++ b/ddo/src/common.rs
@@ -85,6 +85,18 @@ pub struct SubProblem<T> {
 }
 
 // ----------------------------------------------------------------------------
+// --- THRESHOLD --------------------------------------------------------------
+// ----------------------------------------------------------------------------
+/// A threshold is a value that can be stored during the execution of a branch
+/// and bound algorithm. It is associated with a single exact state and is used
+/// to determine whether a new node with the same state is worth exploring.
+#[derive(Debug)]
+pub struct Threshold {
+    pub theta: isize,
+    pub explored: bool,
+}
+
+// ----------------------------------------------------------------------------
 // --- Results ----------------------------------------------------------------
 // ----------------------------------------------------------------------------
 /// A reason explaining why the mdd stopped developing

--- a/ddo/src/implementation/barrier/empty.rs
+++ b/ddo/src/implementation/barrier/empty.rs
@@ -24,16 +24,12 @@
 //! `Relaxation` are defined. These are the two abstractions that one *must*
 //! implement in order to be able to use our library.
 
-mod dp;
-mod heuristics;
-mod solver;
-mod fringe;
-mod mdd;
-mod barrier;
+use crate::*;
 
-pub use dp::*;
-pub use heuristics::*;
-pub use solver::*;
-pub use fringe::*;
-pub use mdd::*;
-pub use barrier::*;
+pub struct EmptyBarrier {
+
+}
+
+impl Barrier for EmptyBarrier {
+    
+}

--- a/ddo/src/implementation/barrier/empty.rs
+++ b/ddo/src/implementation/barrier/empty.rs
@@ -24,12 +24,32 @@
 //! `Relaxation` are defined. These are the two abstractions that one *must*
 //! implement in order to be able to use our library.
 
+use std::{marker::PhantomData, sync::Arc};
+
 use crate::*;
 
-pub struct EmptyBarrier {
-
+/// Dummy implementation of Barrier with no information stored at all.
+pub struct EmptyBarrier<T> {
+    phantom: PhantomData<T>,
 }
 
-impl Barrier for EmptyBarrier {
-    
+impl<T> EmptyBarrier<T> {
+    pub fn new() -> Self {
+        EmptyBarrier { phantom: PhantomData::default() }
+    }
+}
+
+impl<T> Barrier for EmptyBarrier<T> {
+    type State = T;
+
+    fn get_threshold(&self, _: Arc<T>, _: usize) -> Option<Threshold> {
+        None
+    }
+
+    fn update_threshold(&self, _: Arc<T>, _: usize, _: isize, _: bool) {}
+
+    fn clear_layer(&self, _: usize) {}
+
+    fn clear(&self) {}
+
 }

--- a/ddo/src/implementation/barrier/mod.rs
+++ b/ddo/src/implementation/barrier/mod.rs
@@ -24,16 +24,8 @@
 //! `Relaxation` are defined. These are the two abstractions that one *must*
 //! implement in order to be able to use our library.
 
-mod dp;
-mod heuristics;
-mod solver;
-mod fringe;
-mod mdd;
-mod barrier;
+mod empty;
+mod simple;
 
-pub use dp::*;
-pub use heuristics::*;
-pub use solver::*;
-pub use fringe::*;
-pub use mdd::*;
-pub use barrier::*;
+pub use empty::*;
+pub use simple::*;

--- a/ddo/src/implementation/barrier/simple.rs
+++ b/ddo/src/implementation/barrier/simple.rs
@@ -24,16 +24,12 @@
 //! `Relaxation` are defined. These are the two abstractions that one *must*
 //! implement in order to be able to use our library.
 
-mod dp;
-mod heuristics;
-mod solver;
-mod fringe;
-mod mdd;
-mod barrier;
+use crate::*;
 
-pub use dp::*;
-pub use heuristics::*;
-pub use solver::*;
-pub use fringe::*;
-pub use mdd::*;
-pub use barrier::*;
+pub struct SimpleBarrier {
+
+}
+
+impl Barrier for SimpleBarrier {
+    
+}

--- a/ddo/src/implementation/fringe/mod.rs
+++ b/ddo/src/implementation/fringe/mod.rs
@@ -17,29 +17,10 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::SubProblem;
+//! This module provides several alternative implementation of the solver fringe.
 
+mod simple;
+mod no_duplicate;
 
-/// This trait abstracts away the implementation details of the solver frontier
-/// (a.k.a. solver fringe). That is, a Frontier represents the global priority
-/// queue which stores all the nodes remaining to explore.
-pub trait Frontier {
-    type State;
-
-    /// This is how you push a node onto the frontier.
-    fn push(&mut self, node: SubProblem<Self::State>);
-    /// This method yields the most promising node from the frontier.
-    /// # Note:
-    /// The solvers rely on the assumption that a frontier will pop nodes in
-    /// descending upper bound order. Hence, it is a requirement for any fringe
-    /// implementation to enforce that requirement.
-    fn pop(&mut self) -> Option<SubProblem<Self::State>>;
-    /// This method clears the frontier: it removes all nodes from the queue.
-    fn clear(&mut self);
-    /// Yields the length of the queue.
-    fn len(&self) -> usize;
-    /// Returns true iff the finge is empty (len == 0)
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
+pub use simple::*;
+pub use no_duplicate::*;

--- a/ddo/src/implementation/fringe/no_duplicate.rs
+++ b/ddo/src/implementation/fringe/no_duplicate.rs
@@ -17,7 +17,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! This module provides the implementation of a solver frontier that forbids the
+//! This module provides the implementation of a solver fringe that forbids the
 //! co-occurence of two subproblems having the same root state.
 
 use std::{hash::Hash, sync::Arc};
@@ -49,7 +49,7 @@ enum Action {
 /// items remain ordered in the priority queue while guaranteeing that a
 /// given state will only ever be present *ONCE* in the priority queue (the
 /// node with the longest path to state is the only kept copy).
-pub struct NoDupFrontier<O>
+pub struct NoDupFringe<O>
 where
     O: SubProblemRanking,
     O::State: Eq + Hash + Clone,
@@ -68,7 +68,7 @@ where
     recycle_bin: Vec<NodeId>,
 }
 
-impl<O> Frontier for NoDupFrontier<O>
+impl<O> Fringe for NoDupFringe<O>
 where
     O: SubProblemRanking,
     O::State: Eq + Hash + Clone,
@@ -180,7 +180,7 @@ where
     }
 }
 
-impl<O> NoDupFrontier<O>
+impl<O> NoDupFringe<O>
 where
     O: SubProblemRanking,
     O::State: Eq + Hash + Clone,
@@ -325,90 +325,90 @@ where
 
 #[cfg(test)]
 #[allow(clippy::many_single_char_names)]
-mod test_no_dup_frontier {
+mod test_no_dup_fringe {
     use crate::*;
     use std::{sync::Arc, cmp::Ordering};
 
     // by default, it is empty
     #[test]
     fn by_default_it_is_empty() {
-        assert!(empty_frontier().is_empty())
+        assert!(empty_fringe().is_empty())
     }
 
     // when the size is zero, then it is empty
     #[test]
     fn when_the_size_is_zero_then_it_is_empty() {
-        let frontier = empty_frontier();
-        assert_eq!(frontier.len(), 0);
-        assert!(frontier.is_empty());
+        let fringe = empty_fringe();
+        assert_eq!(fringe.len(), 0);
+        assert!(fringe.is_empty());
     }
 
     // when the size is greater than zero, it it not empty
     #[test]
     fn when_the_size_is_greater_than_zero_it_is_not_empty() {
-        let frontier = non_empty_frontier();
-        assert_eq!(frontier.len(), 1);
-        assert!(!frontier.is_empty());
+        let fringe = non_empty_fringe();
+        assert_eq!(fringe.len(), 1);
+        assert!(!fringe.is_empty());
     }
 
-    // when I push a non existing node onto the frontier then the length increases
+    // when I push a non existing node onto the fringe then the length increases
     #[test]
-    fn when_i_push_a_non_existing_node_onto_the_frontier_then_the_length_increases() {
-        let mut frontier = empty_frontier();
-        frontier.push(SubProblem {
+    fn when_i_push_a_non_existing_node_onto_the_fringe_then_the_length_increases() {
+        let mut fringe = empty_fringe();
+        fringe.push(SubProblem {
             state: Arc::new(42),
             value: 0,
             path : vec![],
             ub   : 0
         });
-        assert_eq!(frontier.len(), 1);
-        frontier.push(SubProblem{
+        assert_eq!(fringe.len(), 1);
+        fringe.push(SubProblem{
             state: Arc::new(43),
             value: 0,
             path : vec![],
             ub: 0
         });
-        assert_eq!(frontier.len(), 2);
+        assert_eq!(fringe.len(), 2);
     }
-    // when I push an existing node onto the frontier then the length wont increases
+    // when I push an existing node onto the fringe then the length wont increases
     #[test]
-    fn when_i_push_an_existing_node_onto_the_frontier_then_the_length_does_not_increases() {
-        let mut frontier = empty_frontier();
-        frontier.push(SubProblem {
+    fn when_i_push_an_existing_node_onto_the_fringe_then_the_length_does_not_increases() {
+        let mut fringe = empty_fringe();
+        fringe.push(SubProblem {
             state: Arc::new(42),
             value: 0,
             path : vec![],
             ub   : 0
         });
-        assert_eq!(frontier.len(), 1);
-        frontier.push(SubProblem {
+        assert_eq!(fringe.len(), 1);
+        fringe.push(SubProblem {
             state: Arc::new(42),
             value: 12,
             path : vec![],
             ub   : 5
         });
-        assert_eq!(frontier.len(), 1);
+        assert_eq!(fringe.len(), 1);
     }
-    // when I pop a node off the frontier then the length decreases
+    // when I pop a node off the fringe then the length decreases
     #[test]
-    fn when_i_pop_a_node_off_the_frontier_then_the_length_decreases() {
-        let mut frontier = non_empty_frontier();
-        assert_eq!(frontier.len(), 1);
-        frontier.pop();
-        assert_eq!(frontier.len(), 0);
+    fn when_i_pop_a_node_off_the_fringe_then_the_length_decreases() {
+        let mut fringe = non_empty_fringe();
+        assert_eq!(fringe.len(), 1);
+        fringe.pop();
+        assert_eq!(fringe.len(), 0);
     }
 
-    // when I try to pop a node off an empty frontier, I get none
+    // when I try to pop a node off an empty fringe, I get none
     #[test]
-    fn when_i_try_to_pop_a_node_off_an_empty_frontier_i_get_none() {
-        let mut frontier = empty_frontier();
-        assert_eq!(frontier.pop(), None);
+    fn when_i_try_to_pop_a_node_off_an_empty_fringe_i_get_none() {
+        let mut fringe = empty_fringe();
+        assert_eq!(fringe.pop(), None);
     }
 
     // when I pop a node, it is always the one with the largest ub (then value)
     #[test]
     fn when_i_pop_a_node_it_is_always_the_one_with_the_largest_ub_then_lp() {
-        let mut frontier = empty_frontier();
+        let mut fringe = empty_fringe();
         let a = SubProblem {
             state: Arc::new(1),
             value: 1,
@@ -446,25 +446,25 @@ mod test_no_dup_frontier {
             ub: 5
         };
 
-        frontier.push(a.clone());
-        frontier.push(f.clone());
-        frontier.push(b.clone());
-        frontier.push(d.clone());
-        frontier.push(c.clone());
-        frontier.push(e);
+        fringe.push(a.clone());
+        fringe.push(f.clone());
+        fringe.push(b.clone());
+        fringe.push(d.clone());
+        fringe.push(c.clone());
+        fringe.push(e);
 
-        assert_eq!(frontier.pop(), Some(f));
-        //assert_eq!(frontier.pop(), Some(e)); // node 'e' will never show up
-        assert_eq!(frontier.pop(), Some(d));
-        assert_eq!(frontier.pop(), Some(c));
-        assert_eq!(frontier.pop(), Some(b));
-        assert_eq!(frontier.pop(), Some(a));
+        assert_eq!(fringe.pop(), Some(f));
+        //assert_eq!(fringe.pop(), Some(e)); // node 'e' will never show up
+        assert_eq!(fringe.pop(), Some(d));
+        assert_eq!(fringe.pop(), Some(c));
+        assert_eq!(fringe.pop(), Some(b));
+        assert_eq!(fringe.pop(), Some(a));
     }
 
-    // when I pop a node off the frontier, for which multiple copies have been added
+    // when I pop a node off the fringe, for which multiple copies have been added
     // I retrieve the one with the longest path
     #[test]
-    fn when_i_pop_a_node_off_the_frontier_for_which_multiple_copies_have_been_added_then_i_retrieve_the_one_with_longest_path(){
+    fn when_i_pop_a_node_off_the_fringe_for_which_multiple_copies_have_been_added_then_i_retrieve_the_one_with_longest_path(){
         let pe = vec![
             Decision {variable: Variable(0), value: 4},
         ];
@@ -486,28 +486,28 @@ mod test_no_dup_frontier {
             ub: 5
         };
 
-        let mut frontier = empty_frontier();
-        frontier.push(ne);
-        frontier.push(nf.clone());
+        let mut fringe = empty_fringe();
+        fringe.push(ne);
+        fringe.push(nf.clone());
 
-        assert_eq!(frontier.pop(), Some(nf));
+        assert_eq!(fringe.pop(), Some(nf));
     }
 
-    // when I clear an empty frontier, it remains empty
+    // when I clear an empty fringe, it remains empty
     #[test]
-    fn when_i_clear_an_empty_frontier_it_remains_empty() {
-        let mut frontier = empty_frontier();
-        assert!(frontier.is_empty());
-        frontier.clear();
-        assert!(frontier.is_empty());
+    fn when_i_clear_an_empty_fringe_it_remains_empty() {
+        let mut fringe = empty_fringe();
+        assert!(fringe.is_empty());
+        fringe.clear();
+        assert!(fringe.is_empty());
     }
-    // when I clear a non empty frontier it becomes empty
+    // when I clear a non empty fringe it becomes empty
     #[test]
-    fn when_i_clear_a_non_empty_frontier_it_becomes_empty() {
-        let mut frontier = non_empty_frontier();
-        assert!(!frontier.is_empty());
-        frontier.clear();
-        assert!(frontier.is_empty());
+    fn when_i_clear_a_non_empty_fringe_it_becomes_empty() {
+        let mut fringe = non_empty_fringe();
+        assert!(!fringe.is_empty());
+        fringe.clear();
+        assert!(fringe.is_empty());
     }
 
 
@@ -523,18 +523,18 @@ mod test_no_dup_frontier {
     }
 
         
-    fn empty_frontier() -> NoDupFrontier<MaxUB<'static, UsizeRanking>> {
-        NoDupFrontier::new(MaxUB::new(&UsizeRanking))
+    fn empty_fringe() -> NoDupFringe<MaxUB<'static, UsizeRanking>> {
+        NoDupFringe::new(MaxUB::new(&UsizeRanking))
     }
-    fn non_empty_frontier() -> NoDupFrontier<MaxUB<'static, UsizeRanking>> {
-        let mut frontier = empty_frontier();
-        frontier.push(SubProblem{
+    fn non_empty_fringe() -> NoDupFringe<MaxUB<'static, UsizeRanking>> {
+        let mut fringe = empty_fringe();
+        fringe.push(SubProblem{
             state: Arc::new(42),
             path: vec![],
             value: 0,
             ub: 0
         });
-        frontier
+        fringe
     }
 
     // 
@@ -549,7 +549,7 @@ mod test_no_dup_frontier {
             fnode(5, 10, 104),
         ];
 
-        let mut heap = empty_frontier();
+        let mut heap = empty_fringe();
         push_all(&mut heap, &nodes);
         assert_eq!(5,     heap.len());
         assert_eq!(false, heap.is_empty());
@@ -570,7 +570,7 @@ mod test_no_dup_frontier {
             fnode(5, 10, 104),
         ];
 
-        let mut heap = empty_frontier();
+        let mut heap = empty_fringe();
         push_all(&mut heap, &nodes);
         push_all(&mut heap, &nodes);
         push_all(&mut heap, &nodes);
@@ -611,7 +611,7 @@ mod test_no_dup_frontier {
             fnode(5, 20,  96),
         ];
 
-        let mut heap = empty_frontier();
+        let mut heap = empty_fringe();
         push_all(&mut heap, &nodes_1);
         push_all(&mut heap, &nodes_2);
         push_all(&mut heap, &nodes_3);
@@ -626,12 +626,12 @@ mod test_no_dup_frontier {
         assert_eq!(true, heap.is_empty());
     }
 
-    fn push_all<T: SubProblemRanking<State = usize>>(heap: &mut NoDupFrontier<T>, nodes: &[SubProblem<usize>]) {
+    fn push_all<T: SubProblemRanking<State = usize>>(heap: &mut NoDupFringe<T>, nodes: &[SubProblem<usize>]) {
         for n in nodes.iter() {
             heap.push(n.clone());
         }
     }
-    fn pop_all<T: SubProblemRanking<State = usize>>(heap: &mut NoDupFrontier<T>) -> Vec<usize> {
+    fn pop_all<T: SubProblemRanking<State = usize>>(heap: &mut NoDupFringe<T>) -> Vec<usize> {
         let mut popped = vec![];
         while let Some(n) = heap.pop() {
             popped.push(*n.state)

--- a/ddo/src/implementation/fringe/no_duplicate.rs
+++ b/ddo/src/implementation/fringe/no_duplicate.rs
@@ -359,14 +359,16 @@ mod test_no_dup_fringe {
             state: Arc::new(42),
             value: 0,
             path : vec![],
-            ub   : 0
+            ub   : 0,
+            depth: 0,
         });
         assert_eq!(fringe.len(), 1);
         fringe.push(SubProblem{
             state: Arc::new(43),
             value: 0,
             path : vec![],
-            ub: 0
+            ub: 0,
+            depth: 0,
         });
         assert_eq!(fringe.len(), 2);
     }
@@ -378,14 +380,16 @@ mod test_no_dup_fringe {
             state: Arc::new(42),
             value: 0,
             path : vec![],
-            ub   : 0
+            ub   : 0,
+            depth: 0,
         });
         assert_eq!(fringe.len(), 1);
         fringe.push(SubProblem {
             state: Arc::new(42),
             value: 12,
             path : vec![],
-            ub   : 5
+            ub   : 5,
+            depth: 0,
         });
         assert_eq!(fringe.len(), 1);
     }
@@ -413,37 +417,43 @@ mod test_no_dup_fringe {
             state: Arc::new(1),
             value: 1,
             path : vec![],
-            ub   : 1
+            ub   : 1,
+            depth: 0,
         };
         let b = SubProblem {
             state: Arc::new(2),
             value: 2,
             path : vec![],
-            ub   : 2
+            ub   : 2,
+            depth: 0,
         };
         let c = SubProblem {
             state: Arc::new(3),
             value: 3,
             path : vec![],
-            ub   : 3
+            ub   : 3,
+            depth: 0,
         };
         let d = SubProblem {
             state: Arc::new(4),
             path: vec![],
             value: 4,
-            ub: 4
+            ub: 4,
+            depth: 0,
         };
         let e = SubProblem{
             state: Arc::new(5),
             path: vec![],
             value: 4,
-            ub: 5
+            ub: 5,
+            depth: 0,
         };
         let f = SubProblem{
             state: Arc::new(5),
             path: vec![],
             value: 5,
-            ub: 5
+            ub: 5,
+            depth: 0,
         };
 
         fringe.push(a.clone());
@@ -477,13 +487,15 @@ mod test_no_dup_fringe {
             state: Arc::new(5),
             path: pe,
             value: 4,
-            ub: 5
+            ub: 5,
+            depth: 1,
         };
         let nf = SubProblem{
             state: Arc::new(5),
             path: pf,
             value: 5,
-            ub: 5
+            ub: 5,
+            depth: 1,
         };
 
         let mut fringe = empty_fringe();
@@ -532,7 +544,8 @@ mod test_no_dup_fringe {
             state: Arc::new(42),
             path: vec![],
             value: 0,
-            ub: 0
+            ub: 0,
+            depth: 0,
         });
         fringe
     }
@@ -644,7 +657,8 @@ mod test_no_dup_fringe {
             state: Arc::new(state),
             path : vec![],
             value,
-            ub
+            ub,
+            depth: 0,
         }
     }
 }

--- a/ddo/src/implementation/fringe/simple.rs
+++ b/ddo/src/implementation/fringe/simple.rs
@@ -104,7 +104,8 @@ mod test_simple_fringe {
             state: Arc::new('a'),
             value: 10,
             ub   : 10,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         assert_eq!(fringe.len(), 1);
         assert!(!fringe.is_empty());
@@ -119,13 +120,15 @@ mod test_simple_fringe {
             state: Arc::new('a'),
             value: 10,
             ub   : 10,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('b'),
             value: 20,
             ub   : 20,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
 
         assert_eq!(fringe.len(), 2);
@@ -139,13 +142,15 @@ mod test_simple_fringe {
             state: Arc::new('a'),
             value: 10,
             ub   : 10,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('b'),
             value: 20,
             ub   : 20,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
 
         assert_eq!(fringe.len(), 2);
@@ -172,37 +177,43 @@ mod test_simple_fringe {
             state: Arc::new('a'),
             value: 1,
             ub   : 1,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('b'),
             value: 2,
             ub   : 2,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('c'),
             value: 3,
             ub   : 3,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('d'),
             value: 4,
             ub   : 4,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('e'),
             value: 4,
             ub   : 5,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         fringe.push(SubProblem {
             state: Arc::new('f'),
             value: 5,
             ub   : 5,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
         
         assert_eq!(fringe.pop().unwrap().state.deref(), &'f');
@@ -230,7 +241,8 @@ mod test_simple_fringe {
             state: Arc::new('f'),
             value: 5,
             ub   : 5,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         });
 
         assert!(!fringe.is_empty());

--- a/ddo/src/implementation/fringe/simple.rs
+++ b/ddo/src/implementation/fringe/simple.rs
@@ -17,31 +17,31 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! This module provides the implementation of a simple solver frontier (priority queue)
+//! This module provides the implementation of a simple solver fringe (priority queue)
 
 use binary_heap_plus::BinaryHeap;
 
 use crate::*;
 
 
-/// The simplest frontier implementation you can think of: is basically consists
-/// of a binary heap that pushes and pops frontier nodes
+/// The simplest fringe implementation you can think of: is basically consists
+/// of a binary heap that pushes and pops fringe nodes
 /// 
 /// # Note
-/// This is the default type of frontier for both sequential and parallel 
+/// This is the default type of fringe for both sequential and parallel 
 /// solvers. Hence, you don't need to take any action in order to use the
-/// `SimpleFrontier`.
+/// `SimpleFringe`.
 /// 
-pub struct SimpleFrontier<O: SubProblemRanking> {
+pub struct SimpleFringe<O: SubProblemRanking> {
     heap: BinaryHeap<SubProblem<O::State>, CompareSubProblem<O>>
 }
-impl <O> SimpleFrontier<O> where O: SubProblemRanking {
-    /// This creates a new simple frontier which uses a custiom frontier order.
+impl <O> SimpleFringe<O> where O: SubProblemRanking {
+    /// This creates a new simple fringe which uses a custom fringe order.
     pub fn new(o: O) -> Self {
         Self{ heap: BinaryHeap::from_vec_cmp(vec![], CompareSubProblem::new(o)) }
     }
 }
-impl <O> Frontier for SimpleFrontier<O> where O: SubProblemRanking {
+impl <O> Fringe for SimpleFringe<O> where O: SubProblemRanking {
     type State = O::State;
     
     fn push(&mut self, node: SubProblem<Self::State>) {
@@ -64,7 +64,7 @@ impl <O> Frontier for SimpleFrontier<O> where O: SubProblemRanking {
 
 #[cfg(test)]
 #[allow(clippy::many_single_char_names)]
-mod test_simple_frontier {
+mod test_simple_fringe {
     use crate::*;
     use std::{sync::Arc, cmp::Ordering, ops::Deref};
 
@@ -82,7 +82,7 @@ mod test_simple_frontier {
     #[test]
     fn by_default_it_is_empty() {
         let order = MaxUB::new(&CharRanking); 
-        let front = SimpleFrontier::new(order);
+        let front = SimpleFringe::new(order);
         assert!(front.is_empty())
     }
 
@@ -90,151 +90,151 @@ mod test_simple_frontier {
     #[test]
     fn when_the_size_is_zero_then_it_is_empty() {
         let order = MaxUB::new(&CharRanking); 
-        let frontier = SimpleFrontier::new(order);
-        assert_eq!(frontier.len(), 0);
-        assert!(frontier.is_empty());
+        let fringe = SimpleFringe::new(order);
+        assert_eq!(fringe.len(), 0);
+        assert!(fringe.is_empty());
     } 
     
     // when the size is greater than zero, it it not empty
     #[test]
     fn when_the_size_is_greater_than_zero_it_is_not_empty() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        frontier.push(SubProblem {
+        let mut fringe = SimpleFringe::new(order);
+        fringe.push(SubProblem {
             state: Arc::new('a'),
             value: 10,
             ub   : 10,
             path : vec![]
         });
-        assert_eq!(frontier.len(), 1);
-        assert!(!frontier.is_empty());
+        assert_eq!(fringe.len(), 1);
+        assert!(!fringe.is_empty());
     }
 
-    // when I push a node onto the frontier then the length increases
+    // when I push a node onto the fringe then the length increases
     #[test]
-    fn when_i_push_a_node_onto_the_frontier_then_the_length_increases() {
+    fn when_i_push_a_node_onto_the_fringe_then_the_length_increases() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        frontier.push(SubProblem {
+        let mut fringe = SimpleFringe::new(order);
+        fringe.push(SubProblem {
             state: Arc::new('a'),
             value: 10,
             ub   : 10,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('b'),
             value: 20,
             ub   : 20,
             path : vec![]
         });
 
-        assert_eq!(frontier.len(), 2);
+        assert_eq!(fringe.len(), 2);
     }
-    // when I pop a node off the frontier then the length decreases
+    // when I pop a node off the fringe then the length decreases
     #[test]
-    fn when_i_pop_a_node_off_the_frontier_then_the_length_decreases() {
+    fn when_i_pop_a_node_off_the_fringe_then_the_length_decreases() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        frontier.push(SubProblem {
+        let mut fringe = SimpleFringe::new(order);
+        fringe.push(SubProblem {
             state: Arc::new('a'),
             value: 10,
             ub   : 10,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('b'),
             value: 20,
             ub   : 20,
             path : vec![]
         });
 
-        assert_eq!(frontier.len(), 2);
-        frontier.pop();
-        assert_eq!(frontier.len(), 1);
-        frontier.pop();
-        assert_eq!(frontier.len(), 0);
+        assert_eq!(fringe.len(), 2);
+        fringe.pop();
+        assert_eq!(fringe.len(), 1);
+        fringe.pop();
+        assert_eq!(fringe.len(), 0);
     }
 
-    // when I try to pop a node off an empty frontier, I get none
+    // when I try to pop a node off an empty fringe, I get none
     #[test]
-    fn when_i_try_to_pop_a_node_off_an_empty_frontier_i_get_none() {
+    fn when_i_try_to_pop_a_node_off_an_empty_fringe_i_get_none() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        assert!(frontier.pop().is_none());
+        let mut fringe = SimpleFringe::new(order);
+        assert!(fringe.pop().is_none());
     }
 
     // when I pop a node, it is always the one with the largest ub (then lp_len)
     #[test]
     fn when_i_pop_a_node_it_is_always_the_one_with_the_largest_ub_then_lp() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        frontier.push(SubProblem {
+        let mut fringe = SimpleFringe::new(order);
+        fringe.push(SubProblem {
             state: Arc::new('a'),
             value: 1,
             ub   : 1,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('b'),
             value: 2,
             ub   : 2,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('c'),
             value: 3,
             ub   : 3,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('d'),
             value: 4,
             ub   : 4,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('e'),
             value: 4,
             ub   : 5,
             path : vec![]
         });
-        frontier.push(SubProblem {
+        fringe.push(SubProblem {
             state: Arc::new('f'),
             value: 5,
             ub   : 5,
             path : vec![]
         });
         
-        assert_eq!(frontier.pop().unwrap().state.deref(), &'f');
-        assert_eq!(frontier.pop().unwrap().state.deref(), &'e');
-        assert_eq!(frontier.pop().unwrap().state.deref(), &'d');
-        assert_eq!(frontier.pop().unwrap().state.deref(), &'c');
-        assert_eq!(frontier.pop().unwrap().state.deref(), &'b');
-        assert_eq!(frontier.pop().unwrap().state.deref(), &'a');
+        assert_eq!(fringe.pop().unwrap().state.deref(), &'f');
+        assert_eq!(fringe.pop().unwrap().state.deref(), &'e');
+        assert_eq!(fringe.pop().unwrap().state.deref(), &'d');
+        assert_eq!(fringe.pop().unwrap().state.deref(), &'c');
+        assert_eq!(fringe.pop().unwrap().state.deref(), &'b');
+        assert_eq!(fringe.pop().unwrap().state.deref(), &'a');
     }
-    // when I clear an empty frontier, it remains empty
+    // when I clear an empty fringe, it remains empty
     #[test]
-    fn when_i_clear_an_empty_frontier_it_remains_empty() {
+    fn when_i_clear_an_empty_fringe_it_remains_empty() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        assert!(frontier.is_empty());
-        frontier.clear();
-        assert!(frontier.is_empty());
+        let mut fringe = SimpleFringe::new(order);
+        assert!(fringe.is_empty());
+        fringe.clear();
+        assert!(fringe.is_empty());
     }
-    // when I clear a non empty frontier it becomes empty
+    // when I clear a non empty fringe it becomes empty
     #[test]
-    fn when_i_clear_a_non_empty_frontier_it_becomes_empty() {
+    fn when_i_clear_a_non_empty_fringe_it_becomes_empty() {
         let order = MaxUB::new(&CharRanking); 
-        let mut frontier = SimpleFrontier::new(order);
-        frontier.push(SubProblem {
+        let mut fringe = SimpleFringe::new(order);
+        fringe.push(SubProblem {
             state: Arc::new('f'),
             value: 5,
             ub   : 5,
             path : vec![]
         });
 
-        assert!(!frontier.is_empty());
-        frontier.clear();
-        assert!(frontier.is_empty());
+        assert!(!fringe.is_empty());
+        fringe.clear();
+        assert!(fringe.is_empty());
     }
 }

--- a/ddo/src/implementation/heuristics/cutoff.rs
+++ b/ddo/src/implementation/heuristics/cutoff.rs
@@ -119,7 +119,7 @@ use crate::Cutoff;
 /// let relaxation = KPRelax{pb: &problem};
 /// let width = FixedWidth(100);
 /// let heuristic = KPRanking;
-/// let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 /// #
 /// let mut solver = DefaultSolver::new(
 ///       &problem, 
@@ -128,7 +128,7 @@ use crate::Cutoff;
 ///       &width,
 ///       // this solver will only stop when optimality is proved
 ///       &NoCutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// let outcome = solver.maximize();
 /// ```
 #[derive(Debug, Default, Copy, Clone)]
@@ -236,7 +236,7 @@ impl Cutoff for NoCutoff {
 /// 
 /// // this solver will be allowed to run for 30 seconds
 /// let cutoff = TimeBudget::new(Duration::from_secs(30));
-/// let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 /// #
 /// let mut solver = DefaultSolver::new(
 ///       &problem, 
@@ -244,7 +244,7 @@ impl Cutoff for NoCutoff {
 ///       &heuristic, 
 ///       &width,
 ///       &cutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// let outcome = solver.maximize();
 /// ```
 #[derive(Debug, Clone)]

--- a/ddo/src/implementation/heuristics/subproblem_ranking.rs
+++ b/ddo/src/implementation/heuristics/subproblem_ranking.rs
@@ -18,14 +18,14 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 //! This module provides the implementation of subproblem rankings that are used to
-//! set the ordering of the solver frontier.
+//! set the ordering of the solver fringe.
 
 use std::cmp::Ordering;
 
 use crate::{StateRanking, SubProblemRanking, SubProblem};
 
 /// The MaxUB (maximum upper bound) strategy is one that always selects the node
-/// having the highest upper bound in the frontier. In case of equalities, the
+/// having the highest upper bound in the fringe. In case of equalities, the
 /// ties are broken using the length of the longest path and eventually a state 
 /// ranking.
 /// 
@@ -57,7 +57,7 @@ use crate::{StateRanking, SubProblemRanking, SubProblem};
 /// let f = SubProblem {state: Arc::new('f'), value: 19, ub: 100, path: vec![]};
 ///
 /// let ranking = MaxUB::new(&CharRanking);
-/// let mut priority_q = SimpleFrontier::new(ranking);
+/// let mut priority_q = SimpleFringe::new(ranking);
 /// priority_q.push(a);
 /// priority_q.push(b);
 /// priority_q.push(c);

--- a/ddo/src/implementation/heuristics/subproblem_ranking.rs
+++ b/ddo/src/implementation/heuristics/subproblem_ranking.rs
@@ -114,12 +114,12 @@ mod test_maxub {
 
     #[test]
     fn example() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
-        let b = SubProblem {state: Arc::new('b'), value:  2, ub: 100, path: vec![]};
-        let c = SubProblem {state: Arc::new('c'), value: 24, ub: 150, path: vec![]};
-        let d = SubProblem {state: Arc::new('d'), value: 13, ub:  60, path: vec![]};
-        let e = SubProblem {state: Arc::new('e'), value: 65, ub: 700, path: vec![]};
-        let f = SubProblem {state: Arc::new('f'), value: 19, ub: 100, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
+        let b = SubProblem {state: Arc::new('b'), value:  2, ub: 100, path: vec![], depth: 0};
+        let c = SubProblem {state: Arc::new('c'), value: 24, ub: 150, path: vec![], depth: 0};
+        let d = SubProblem {state: Arc::new('d'), value: 13, ub:  60, path: vec![], depth: 0};
+        let e = SubProblem {state: Arc::new('e'), value: 65, ub: 700, path: vec![], depth: 0};
+        let f = SubProblem {state: Arc::new('f'), value: 19, ub: 100, path: vec![], depth: 0};
 
         let nodes = vec![a, b, c, d, e, f];
         let mut priority_q = BinaryHeap::from_vec_cmp(nodes, CompareSubProblem::new(MaxUB::new(&CharRanking)));
@@ -134,42 +134,42 @@ mod test_maxub {
 
     #[test]
     fn gt_because_ub() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
-        let b = SubProblem {state: Arc::new('b'), value: 42, ub: 100, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
+        let b = SubProblem {state: Arc::new('b'), value: 42, ub: 100, path: vec![], depth: 0};
         let cmp = MaxUB::new(&CharRanking);
         assert_eq!(Ordering::Greater, cmp.compare(&a, &b));
     }
     #[test]
     fn gt_because_lplen() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
-        let b = SubProblem {state: Arc::new('b'), value:  2, ub: 300, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
+        let b = SubProblem {state: Arc::new('b'), value:  2, ub: 300, path: vec![], depth: 0};
         let cmp = MaxUB::new(&CharRanking);
         assert_eq!(Ordering::Greater, cmp.compare(&a, &b));
     }
     #[test]
     fn lt_because_ub() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
-        let b = SubProblem {state: Arc::new('b'), value: 42, ub: 100, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
+        let b = SubProblem {state: Arc::new('b'), value: 42, ub: 100, path: vec![], depth: 0};
         let cmp = MaxUB::new(&CharRanking);
         assert_eq!(Ordering::Less, cmp.compare(&b, &a));
     }
     #[test]
     fn lt_because_lplen() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
-        let b = SubProblem {state: Arc::new('b'), value:  2, ub: 300, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
+        let b = SubProblem {state: Arc::new('b'), value:  2, ub: 300, path: vec![], depth: 0};
         let cmp = MaxUB::new(&CharRanking);
         assert_eq!(Ordering::Less, cmp.compare(&b, &a));
     }
     #[test]
     fn lt_because_state() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
-        let b = SubProblem {state: Arc::new('b'), value: 42, ub: 300, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
+        let b = SubProblem {state: Arc::new('b'), value: 42, ub: 300, path: vec![], depth: 0};
         let cmp = MaxUB::new(&CharRanking);
         assert_eq!(Ordering::Less, cmp.compare(&a, &b));
     }
     #[test]
     fn eq_self() {
-        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![]};
+        let a = SubProblem {state: Arc::new('a'), value: 42, ub: 300, path: vec![], depth: 0};
         let cmp = MaxUB::new(&CharRanking);
         assert_eq!(Ordering::Equal, cmp.compare(&a, &a));
     }

--- a/ddo/src/implementation/heuristics/utils.rs
+++ b/ddo/src/implementation/heuristics/utils.rs
@@ -108,24 +108,24 @@ mod test {
     fn when_a_is_less_than_b_comparesubproblem_returns_less() {
         let cmp = CompareSubProblem::new(CharRanking);
         assert_eq!(cmp.compare(
-            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![]}, 
-            &SubProblem{state: Arc::new('b'), value: 0, ub: isize::MAX, path: vec![]}), 
+            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![], depth: 0}, 
+            &SubProblem{state: Arc::new('b'), value: 0, ub: isize::MAX, path: vec![], depth: 0}), 
             Ordering::Less);
     }
     #[test]
     fn when_a_is_greater_than_b_comparesubproblem_returns_greater() {
         let cmp = CompareSubProblem::new(CharRanking);
         assert_eq!(cmp.compare(
-            &SubProblem{state: Arc::new('b'), value: 0, ub: isize::MAX, path: vec![]}, 
-            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![]}), 
+            &SubProblem{state: Arc::new('b'), value: 0, ub: isize::MAX, path: vec![], depth: 0}, 
+            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![], depth: 0}), 
             Ordering::Greater);
     }
     #[test]
     fn when_a_is_equal_to_b_comparesubproblem_returns_equal() {
         let cmp = CompareSubProblem::new(CharRanking);
         assert_eq!(cmp.compare(
-            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![]}, 
-            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![]}), 
+            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![], depth: 0}, 
+            &SubProblem{state: Arc::new('a'), value: 0, ub: isize::MAX, path: vec![], depth: 0}), 
             Ordering::Equal);
     }
 }

--- a/ddo/src/implementation/heuristics/width.rs
+++ b/ddo/src/implementation/heuristics/width.rs
@@ -785,7 +785,8 @@ mod test_nbunassigned {
             state: Arc::new('a'),
             value: 10,
             ub   : 100,
-            path : vec![Decision{variable: Variable(0), value: 4}]
+            path : vec![Decision{variable: Variable(0), value: 4}],
+            depth: 1,
         };
         assert_eq!(4, heu.max_width(&sub));
     }
@@ -796,7 +797,8 @@ mod test_nbunassigned {
             state: Arc::new('a'),
             value: 10,
             ub   : 100,
-            path : vec![] // no decision made, all vars are available
+            path : vec![], // no decision made, all vars are available
+            depth: 0,
         };
         assert_eq!(5, heu.max_width(&sub));
     }
@@ -815,7 +817,8 @@ mod test_nbunassigned {
                 Decision{variable: Variable(2), value: 2},
                 Decision{variable: Variable(3), value: 3},
                 Decision{variable: Variable(4), value: 4},
-                ]
+                ],
+            depth: 5,
         };
         assert_eq!(0, heu.max_width(&sub));
     }
@@ -835,7 +838,8 @@ mod test_fixedwidth {
             ub   : 100,
             path : vec![
                 Decision{variable: Variable(0), value: 0},
-                ]
+                ],
+            depth: 1,
         };
         assert_eq!(5, heu.max_width(&sub));
     }
@@ -846,7 +850,8 @@ mod test_fixedwidth {
             state: Arc::new('a'),
             value: 10,
             ub   : 100,
-            path : vec![]
+            path : vec![],
+            depth: 0,
         };
         assert_eq!(5, heu.max_width(&sub));
     }
@@ -864,7 +869,8 @@ mod test_fixedwidth {
                 Decision{variable: Variable(2), value: 2},
                 Decision{variable: Variable(3), value: 3},
                 Decision{variable: Variable(4), value: 4},
-                ]
+                ],
+            depth: 5,
         };
         assert_eq!(5, heu.max_width(&sub));
     }
@@ -889,7 +895,8 @@ mod test_adapters {
                 Decision{variable: Variable(2), value: 2},
                 Decision{variable: Variable(3), value: 3},
                 Decision{variable: Variable(4), value: 4},
-                ]
+                ],
+            depth: 5,
         };
         assert_eq!(10, Times( 2, heu).max_width(&sub));
         assert_eq!(15, Times( 3, heu).max_width(&sub));
@@ -909,7 +916,8 @@ mod test_adapters {
                 Decision{variable: Variable(2), value: 2},
                 Decision{variable: Variable(3), value: 3},
                 Decision{variable: Variable(4), value: 4},
-                ]
+                ],
+            depth: 5,
         };
         assert_eq!( 2, DivBy( 2, FixedWidth(4)).max_width(&sub));
         assert_eq!( 3, DivBy( 3, FixedWidth(9)).max_width(&sub));
@@ -929,7 +937,8 @@ mod test_adapters {
                 Decision{variable: Variable(2), value: 2},
                 Decision{variable: Variable(3), value: 3},
                 Decision{variable: Variable(4), value: 4},
-                ]
+                ],
+            depth: 5,
         };
         assert_eq!( 1, Times( 0, FixedWidth(10)).max_width(&sub));
         assert_eq!( 1, Times(10, FixedWidth( 0)).max_width(&sub));
@@ -948,7 +957,8 @@ mod test_adapters {
                 Decision{variable: Variable(2), value: 2},
                 Decision{variable: Variable(3), value: 3},
                 Decision{variable: Variable(4), value: 4},
-                ]
+                ],
+            depth: 5,
         };
         DivBy( 0, FixedWidth(0)).max_width(&sub);
     }

--- a/ddo/src/implementation/heuristics/width.rs
+++ b/ddo/src/implementation/heuristics/width.rs
@@ -129,7 +129,7 @@ use crate::{WidthHeuristic, SubProblem};
 /// # let relaxation = KPRelax{pb: &problem};
 /// # let heuristic = KPRanking;
 /// # let cutoff = NoCutoff; // might as well be a TimeBudget (or something else) 
-/// # let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// # let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 /// #
 /// let mut solver = DefaultSolver::new(
 ///       &problem, 
@@ -137,7 +137,7 @@ use crate::{WidthHeuristic, SubProblem};
 ///       &heuristic, 
 ///       &FixedWidth(100), // all DDs will be compiled with a maximum width of 100 nodes 
 ///       &cutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// ```
 #[derive(Debug, Copy, Clone)]
 pub struct FixedWidth(pub usize);
@@ -331,7 +331,7 @@ impl <X> WidthHeuristic<X> for FixedWidth {
 /// let relaxation = KPRelax{pb: &problem};
 /// let heuristic = KPRanking;
 /// let cutoff = NoCutoff; // might as well be a TimeBudget (or something else) 
-/// let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 /// #
 /// let mut solver = DefaultSolver::new(
 ///       &problem, 
@@ -339,7 +339,7 @@ impl <X> WidthHeuristic<X> for FixedWidth {
 ///       &heuristic, 
 ///       &NbUnassignedWitdh(problem.nb_variables()),
 ///       &cutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// ```
 #[derive(Default, Debug, Copy, Clone)]
 pub struct NbUnassignedWitdh(pub usize);
@@ -541,7 +541,7 @@ impl <X> WidthHeuristic<X> for NbUnassignedWitdh {
 /// let relaxation = KPRelax{pb: &problem};
 /// let heuristic = KPRanking;
 /// let cutoff = NoCutoff; // might as well be a TimeBudget (or something else) 
-/// let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 /// #
 /// let mut solver = DefaultSolver::new(
 ///       &problem, 
@@ -549,7 +549,7 @@ impl <X> WidthHeuristic<X> for NbUnassignedWitdh {
 ///       &heuristic, 
 ///       &Times(5, NbUnassignedWitdh(problem.nb_variables())),
 ///       &cutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct Times<X>(pub usize, pub X);
@@ -751,7 +751,7 @@ impl <S, X: WidthHeuristic<S>> WidthHeuristic<S> for Times<X> {
 /// let relaxation = KPRelax{pb: &problem};
 /// let heuristic = KPRanking;
 /// let cutoff = NoCutoff; // might as well be a TimeBudget (or something else) 
-/// let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 /// #
 /// let mut solver = DefaultSolver::new(
 ///       &problem, 
@@ -759,7 +759,7 @@ impl <S, X: WidthHeuristic<S>> WidthHeuristic<S> for Times<X> {
 ///       &heuristic, 
 ///       &DivBy(2, NbUnassignedWitdh(problem.nb_variables())),
 ///       &cutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct DivBy<X>(pub usize, pub X);

--- a/ddo/src/implementation/mdd/node_flags.rs
+++ b/ddo/src/implementation/mdd/node_flags.rs
@@ -55,6 +55,10 @@ impl NodeFlags {
     pub const F_MARKED: u8 = 4;
     /// The position of the cutset flag.
     pub const F_CUTSET: u8 = 8;
+    /// The position of the deleted flag.
+    pub const F_DELETED: u8 = 16;
+    /// The position of the barrier flag.
+    pub const F_BARRIER: u8 = 32;
 
     /// Creates a new set of flags, either initialized with exact on or with
     /// relaxed on.
@@ -98,6 +102,16 @@ impl NodeFlags {
     pub fn is_cutset(self) -> bool {
         self.test(NodeFlags::F_CUTSET)
     }
+    /// Returns true iff the deleted flag is turned on
+    #[inline]
+    pub fn is_deleted(self) -> bool {
+        self.test(NodeFlags::F_DELETED)
+    }
+    /// Returns true iff the barrier flag is turned on
+    #[inline]
+    pub fn is_pruned_by_barrier(self) -> bool {
+        self.test(NodeFlags::F_BARRIER)
+    }
     /// Sets the exact flag to the given value
     #[inline]
     pub fn set_exact(&mut self, exact: bool) {
@@ -117,6 +131,16 @@ impl NodeFlags {
     #[inline]
     pub fn set_cutset(&mut self, cutset: bool) {
         self.set(NodeFlags::F_CUTSET, cutset)
+    }
+    /// Sets the deleted flag to the given value
+    #[inline]
+    pub fn set_deleted(&mut self, deleted: bool) {
+        self.set(NodeFlags::F_DELETED, deleted)
+    }
+    /// Sets the barrier flag to the given value
+    #[inline]
+    pub fn set_pruned_by_barrier(&mut self, barrier: bool) {
+        self.set(NodeFlags::F_BARRIER, barrier)
     }
     /// Checks whether all the flags encoded in the given mask are turned on.
     /// Otherwise, it returns false

--- a/ddo/src/implementation/mdd/node_flags.rs
+++ b/ddo/src/implementation/mdd/node_flags.rs
@@ -262,36 +262,128 @@ mod test_node_flags {
         assert_eq!(true, tested.is_marked());
     }
     #[test]
+    fn is_cutset_iff_marked_so() {
+        let mut tested = NodeFlags::new_exact();
+        assert_eq!(false, tested.is_cutset());
+
+        tested.set_cutset(true);
+        assert_eq!(true, tested.is_cutset());
+
+        tested.set_cutset(false);
+        assert_eq!(false, tested.is_cutset());
+
+        tested.set_cutset(true);
+        assert_eq!(true, tested.is_cutset());
+    }
+    #[test]
+    fn is_deleted_iff_marked_so() {
+        let mut tested = NodeFlags::new_exact();
+        assert_eq!(false, tested.is_deleted());
+
+        tested.set_deleted(true);
+        assert_eq!(true, tested.is_deleted());
+
+        tested.set_deleted(false);
+        assert_eq!(false, tested.is_deleted());
+
+        tested.set_deleted(true);
+        assert_eq!(true, tested.is_deleted());
+    }
+    #[test]
+    fn is_pruned_by_barrier_iff_marked_so() {
+        let mut tested = NodeFlags::new_exact();
+        assert_eq!(false, tested.is_pruned_by_barrier());
+
+        tested.set_pruned_by_barrier(true);
+        assert_eq!(true, tested.is_pruned_by_barrier());
+
+        tested.set_pruned_by_barrier(false);
+        assert_eq!(false, tested.is_pruned_by_barrier());
+
+        tested.set_pruned_by_barrier(true);
+        assert_eq!(true, tested.is_pruned_by_barrier());
+    }
+    #[test]
     fn test_yields_the_value_of_the_flag() {
         let mut tested = NodeFlags::new_exact();
         assert_eq!(true, tested.test(NodeFlags::F_EXACT));
         assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
         assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
 
         tested.set_relaxed(true);
         assert_eq!(true, tested.test(NodeFlags::F_EXACT));
         assert_eq!(true, tested.test(NodeFlags::F_RELAXED));
         assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
 
         tested.set_marked(true);
         assert_eq!(true, tested.test(NodeFlags::F_EXACT));
         assert_eq!(true, tested.test(NodeFlags::F_RELAXED));
         assert_eq!(true, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
 
         tested.set_exact(false);
         assert_eq!(false, tested.test(NodeFlags::F_EXACT));
         assert_eq!(true, tested.test(NodeFlags::F_RELAXED));
         assert_eq!(true, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
 
         tested.set_relaxed(false);
         assert_eq!(false, tested.test(NodeFlags::F_EXACT));
         assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
         assert_eq!(true, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
 
         tested.set_marked(false);
         assert_eq!(false, tested.test(NodeFlags::F_EXACT));
         assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
         assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
+
+        tested.set_deleted(true);
+        assert_eq!(false, tested.test(NodeFlags::F_EXACT));
+        assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
+        assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(true, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
+
+        tested.set_pruned_by_barrier(true);
+        assert_eq!(false, tested.test(NodeFlags::F_EXACT));
+        assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
+        assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(true, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(true, tested.test(NodeFlags::F_BARRIER));
+
+        tested.set_deleted(false);
+        assert_eq!(false, tested.test(NodeFlags::F_EXACT));
+        assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
+        assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(true, tested.test(NodeFlags::F_BARRIER));
+
+        tested.set_pruned_by_barrier(false);
+        assert_eq!(false, tested.test(NodeFlags::F_EXACT));
+        assert_eq!(false, tested.test(NodeFlags::F_RELAXED));
+        assert_eq!(false, tested.test(NodeFlags::F_MARKED));
+        assert_eq!(false, tested.test(NodeFlags::F_CUTSET));
+        assert_eq!(false, tested.test(NodeFlags::F_DELETED));
+        assert_eq!(false, tested.test(NodeFlags::F_BARRIER));
     }
     #[test]
     fn test_checks_the_value_of_more_than_one_flag() {
@@ -611,5 +703,8 @@ mod test_node_flags {
         assert_eq!(true, NodeFlags::default().test(NodeFlags::F_EXACT));
         assert_eq!(false, NodeFlags::default().test(NodeFlags::F_RELAXED));
         assert_eq!(false, NodeFlags::default().test(NodeFlags::F_MARKED));
+        assert_eq!(false, NodeFlags::default().test(NodeFlags::F_CUTSET));
+        assert_eq!(false, NodeFlags::default().test(NodeFlags::F_DELETED));
+        assert_eq!(false, NodeFlags::default().test(NodeFlags::F_BARRIER));
     }
 }

--- a/ddo/src/implementation/mdd/vector_based.rs
+++ b/ddo/src/implementation/mdd/vector_based.rs
@@ -601,7 +601,7 @@ mod test_default_mdd {
     }
 
     #[test]
-    fn root_remembers_the_pa_from_the_frontier_node() {
+    fn root_remembers_the_pa_from_the_fringe_node() {
         let mut input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyProblem,

--- a/ddo/src/implementation/mdd/vector_based.rs
+++ b/ddo/src/implementation/mdd/vector_based.rs
@@ -591,7 +591,7 @@ mod test_default_mdd {
 
     use rustc_hash::FxHashMap;
 
-    use crate::{Variable, VectorBased, DecisionDiagram, SubProblem, CompilationInput, Problem, Decision, Relaxation, StateRanking, NoCutoff, CompilationType, Cutoff, Reason, DecisionCallback, CutsetType};
+    use crate::{Variable, VectorBased, DecisionDiagram, SubProblem, CompilationInput, Problem, Decision, Relaxation, StateRanking, NoCutoff, CompilationType, Cutoff, Reason, DecisionCallback, CutsetType, EmptyBarrier};
 
     #[test]
     fn by_default_the_mdd_type_is_exact() {
@@ -602,6 +602,7 @@ mod test_default_mdd {
 
     #[test]
     fn root_remembers_the_pa_from_the_fringe_node() {
+        let mut barrier = EmptyBarrier{};
         let mut input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyProblem,
@@ -615,7 +616,8 @@ mod test_default_mdd {
                 value: 42, 
                 path:  vec![Decision{variable: Variable(0), value: 42}], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
 
         let mut mdd = VectorBased::new();
@@ -634,6 +636,7 @@ mod test_default_mdd {
     // In an exact setup, the dummy problem would be 3*3*3 = 9 large at the bottom level
     #[test]
     fn exact_completely_unrolls_the_mdd_no_matter_its_width() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyProblem,
@@ -647,7 +650,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
 
@@ -665,6 +669,7 @@ mod test_default_mdd {
 
     #[test]
     fn restricted_drops_the_less_interesting_nodes() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Restricted,
             problem:    &DummyProblem,
@@ -678,7 +683,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
 
@@ -696,6 +702,7 @@ mod test_default_mdd {
 
     #[test]
     fn exact_no_cutoff_completion_must_be_coherent_with_outcome() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyProblem,
@@ -709,7 +716,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -721,6 +729,7 @@ mod test_default_mdd {
     }
     #[test]
     fn restricted_no_cutoff_completion_must_be_coherent_with_outcome_() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Restricted,
             problem:    &DummyProblem,
@@ -734,7 +743,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -746,6 +756,7 @@ mod test_default_mdd {
     }
     #[test]
     fn relaxed_no_cutoff_completion_must_be_coherent_with_outcome() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -759,7 +770,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -777,6 +789,7 @@ mod test_default_mdd {
     }
     #[test]
     fn exact_fails_with_cutoff_when_cutoff_occurs() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyProblem,
@@ -790,7 +803,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -800,6 +814,7 @@ mod test_default_mdd {
 
     #[test]
     fn restricted_fails_with_cutoff_when_cutoff_occurs() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Restricted,
             problem:    &DummyProblem,
@@ -813,7 +828,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -822,6 +838,7 @@ mod test_default_mdd {
     }
     #[test]
     fn relaxed_fails_with_cutoff_when_cutoff_occurs() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -835,7 +852,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -845,6 +863,7 @@ mod test_default_mdd {
 
     #[test]
     fn relaxed_merges_the_less_interesting_nodes() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -858,7 +877,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -877,6 +897,7 @@ mod test_default_mdd {
 
     #[test]
     fn relaxed_populates_the_cutset_and_will_not_squash_first_layer() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -890,7 +911,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -903,6 +925,7 @@ mod test_default_mdd {
 
     #[test]
     fn an_exact_mdd_must_be_exact() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyProblem,
@@ -916,7 +939,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -927,6 +951,7 @@ mod test_default_mdd {
 
     #[test]
     fn a_relaxed_mdd_is_exact_as_long_as_no_merge_occurs() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -940,7 +965,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -951,6 +977,7 @@ mod test_default_mdd {
 
     #[test]
     fn a_relaxed_mdd_is_not_exact_when_a_merge_occured() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -964,7 +991,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -974,6 +1002,7 @@ mod test_default_mdd {
     }
     #[test]
     fn a_restricted_mdd_is_exact_as_long_as_no_restriction_occurs() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Restricted,
             problem:    &DummyProblem,
@@ -987,7 +1016,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -997,6 +1027,7 @@ mod test_default_mdd {
     }
     #[test]
     fn a_restricted_mdd_is_not_exact_when_a_restriction_occured() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyProblem,
@@ -1010,7 +1041,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -1020,6 +1052,7 @@ mod test_default_mdd {
     }
     #[test]
     fn when_the_problem_is_infeasible_there_is_no_solution() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyInfeasibleProblem,
@@ -1033,7 +1066,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -1042,6 +1076,7 @@ mod test_default_mdd {
     }
     #[test]
     fn when_the_problem_is_infeasible_there_is_no_best_value() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyInfeasibleProblem,
@@ -1055,7 +1090,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -1064,6 +1100,7 @@ mod test_default_mdd {
     }
     #[test]
     fn exact_skips_node_with_an_ub_less_than_best_known_lb() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Exact,
             problem:    &DummyInfeasibleProblem,
@@ -1077,7 +1114,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -1086,6 +1124,7 @@ mod test_default_mdd {
     }
     #[test]
     fn relaxed_skips_node_with_an_ub_less_than_best_known_lb() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &DummyInfeasibleProblem,
@@ -1099,7 +1138,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -1108,6 +1148,7 @@ mod test_default_mdd {
     }
     #[test]
     fn restricted_skips_node_with_an_ub_less_than_best_known_lb() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Restricted,
             problem:    &DummyInfeasibleProblem,
@@ -1121,7 +1162,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);
@@ -1236,6 +1278,7 @@ mod test_default_mdd {
 
     #[test]
     fn relaxed_computes_local_bounds() {
+        let mut barrier = EmptyBarrier{};
         let input = CompilationInput {
             comp_type: crate::CompilationType::Relaxed(CutsetType::LastExactLayer),
             problem:    &LocBoundsExamplePb,
@@ -1249,7 +1292,8 @@ mod test_default_mdd {
                 value: 0, 
                 path:  vec![], 
                 ub:    isize::MAX
-            }
+            },
+            barrier: Arc::new(&mut barrier),
         };
         let mut mdd = VectorBased::new();
         let result = mdd.compile(&input);

--- a/ddo/src/implementation/mod.rs
+++ b/ddo/src/implementation/mod.rs
@@ -23,9 +23,11 @@
 mod heuristics;
 mod fringe;
 mod mdd;
+mod barrier;
 mod solver;
 
 pub use heuristics::*;
 pub use fringe::*;
 pub use mdd::*;
+pub use barrier::*;
 pub use solver::*;

--- a/ddo/src/implementation/mod.rs
+++ b/ddo/src/implementation/mod.rs
@@ -21,11 +21,11 @@
 //! abstractions of the library (those are described in `ddo::abstraction::*`).
 
 mod heuristics;
-mod frontier;
+mod fringe;
 mod mdd;
 mod solver;
 
 pub use heuristics::*;
-pub use frontier::*;
+pub use fringe::*;
 pub use mdd::*;
 pub use solver::*;

--- a/ddo/src/implementation/solver/parallel.rs
+++ b/ddo/src/implementation/solver/parallel.rs
@@ -1054,6 +1054,95 @@ mod test_solver {
     }
 
     #[test]
+    fn maximizes_yields_the_optimum_2c() {
+        let problem = Knapsack {
+            capacity: 50,
+            profit  : vec![60, 210, 12, 5, 100, 120, 110],
+            weight  : vec![10,  45, 20, 4,  20,  30,  50]
+        };
+        let relax = KPRelax {pb: &&problem};
+        let ranking = KPRanking;
+        let cutoff = NoCutoff;
+        let width = NbUnassignedWitdh(problem.nb_variables());
+        let cutset = CutsetType::LastExactLayer;
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
+        let barrier = SimpleBarrier::new(problem.nb_variables());
+        let mut solver = DD::custom(
+            &problem,
+            &relax,
+            &ranking,
+            &width,
+            cutset,
+            &cutoff,
+            &mut fringe,
+            &barrier,
+            1,
+        );
+
+        let maximized = solver.maximize();
+
+        assert!(maximized.is_exact);
+        assert_eq!(maximized.best_value, Some(220));
+        assert!(solver.best_solution().is_some());
+
+        let mut sln = solver.best_solution().unwrap();
+        sln.sort_unstable_by_key(|d| d.variable.id());
+        assert_eq!(sln, vec![
+            Decision { variable: Variable(0), value: 0 },
+            Decision { variable: Variable(1), value: 0 },
+            Decision { variable: Variable(2), value: 0 },
+            Decision { variable: Variable(3), value: 0 },
+            Decision { variable: Variable(4), value: 1 },
+            Decision { variable: Variable(5), value: 1 },
+            Decision { variable: Variable(6), value: 0 }
+        ]);
+    }
+
+    #[test]
+    fn maximizes_yields_the_optimum_2d() {
+        let problem = Knapsack {
+            capacity: 50,
+            profit  : vec![60, 210, 12, 5, 100, 120, 110],
+            weight  : vec![10,  45, 20, 4,  20,  30,  50]
+        };
+        let relax = KPRelax {pb: &&problem};
+        let ranking = KPRanking;
+        let cutoff = NoCutoff;
+        let width = NbUnassignedWitdh(problem.nb_variables());
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
+        let barrier = SimpleBarrier::new(problem.nb_variables());
+        let mut solver = DD::custom(
+            &problem,
+            &relax,
+            &ranking,
+            &width,
+            CutsetType::Frontier,
+            &cutoff,
+            &mut fringe,
+            &barrier,
+            1,
+        );
+
+        let maximized = solver.maximize();
+
+        assert!(maximized.is_exact);
+        assert_eq!(maximized.best_value, Some(220));
+        assert!(solver.best_solution().is_some());
+
+        let mut sln = solver.best_solution().unwrap();
+        sln.sort_unstable_by_key(|d| d.variable.id());
+        assert_eq!(sln, vec![
+            Decision { variable: Variable(0), value: 0 },
+            Decision { variable: Variable(1), value: 0 },
+            Decision { variable: Variable(2), value: 0 },
+            Decision { variable: Variable(3), value: 0 },
+            Decision { variable: Variable(4), value: 1 },
+            Decision { variable: Variable(5), value: 1 },
+            Decision { variable: Variable(6), value: 0 }
+        ]);
+    }
+
+    #[test]
     fn set_primal_overwrites_best_value_and_sol_if_it_improves() {
         let problem = Knapsack {
             capacity: 50,

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -788,7 +788,7 @@ mod test_solver {
     }
 
     #[test]
-    fn maximizes_yields_the_optimum_2() {
+    fn maximizes_yields_the_optimum_2a() {
         let problem = Knapsack {
             capacity: 50,
             profit  : vec![60, 210, 12, 5, 100, 120, 110],
@@ -828,6 +828,49 @@ mod test_solver {
             Decision { variable: Variable(6), value: 0 }
         ]);
     }
+
+    #[test]
+    fn maximizes_yields_the_optimum_2b() {
+        let problem = Knapsack {
+            capacity: 50,
+            profit  : vec![60, 210, 12, 5, 100, 120, 110],
+            weight  : vec![10,  45, 20, 4,  20,  30,  50]
+        };
+        let relax = KPRelax {pb: &&problem};
+        let ranking = KPRanking;
+        let cutoff = NoCutoff;
+        let width = NbUnassignedWitdh(problem.nb_variables());
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
+        let barrier = SimpleBarrier::new(problem.nb_variables());
+        let mut solver = SequentialSolver::new(
+            &problem,
+            &relax,
+            &ranking,
+            &width,
+            &cutoff,
+            &mut fringe,
+            &barrier,
+        );
+
+        let maximized = solver.maximize();
+
+        assert!(maximized.is_exact);
+        assert_eq!(maximized.best_value, Some(220));
+        assert!(solver.best_solution().is_some());
+
+        let mut sln = solver.best_solution().unwrap();
+        sln.sort_unstable_by_key(|d| d.variable.id());
+        assert_eq!(sln, vec![
+            Decision { variable: Variable(0), value: 0 },
+            Decision { variable: Variable(1), value: 0 },
+            Decision { variable: Variable(2), value: 0 },
+            Decision { variable: Variable(3), value: 0 },
+            Decision { variable: Variable(4), value: 1 },
+            Decision { variable: Variable(5), value: 1 },
+            Decision { variable: Variable(6), value: 0 }
+        ]);
+    }
+
     #[test]
     fn set_primal_overwrites_best_value_and_sol_if_it_improves() {
         let problem = Knapsack {

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -28,7 +28,7 @@
 use std::clone::Clone;
 use std::{sync::Arc, hash::Hash};
 
-use crate::{Frontier, Decision, Problem, Relaxation, StateRanking, WidthHeuristic, Cutoff, SubProblem, DecisionDiagram, DefaultMDD, CompilationInput, CompilationType, Solver, Solution, Completion, Reason, CutsetType};
+use crate::{Fringe, Decision, Problem, Relaxation, StateRanking, WidthHeuristic, Cutoff, SubProblem, DecisionDiagram, DefaultMDD, CompilationInput, CompilationType, Solver, Solution, Completion, Reason, CutsetType};
 
 /// The workload a thread can get from the shared state
 enum WorkLoad<T> {
@@ -141,8 +141,8 @@ enum WorkLoad<T> {
 /// // 5. Decide of a cutoff heuristic (if you dont want to let the solver run for ever)
 /// let cutoff = NoCutoff; // might as well be a TimeBudget (or something else)
 /// 
-/// // 5. Create the solver frontier
-/// let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+/// // 5. Create the solver fringe
+/// let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 ///  
 /// // 6. Instanciate your solver
 /// let mut solver = DefaultSolver::new(
@@ -151,7 +151,7 @@ enum WorkLoad<T> {
 ///       &heuristic, 
 ///       &width, 
 ///       &cutoff, 
-///       &mut frontier);
+///       &mut fringe);
 /// 
 /// // 7. Maximize your objective function
 /// // the outcome provides the value of the best solution that was found for
@@ -203,7 +203,7 @@ where D: DecisionDiagram<State = State> + Default,
     /// any of the nodes remaining on the fringe. As a consequence, the
     /// exploration can be stopped as soon as a node with an ub <= current best
     /// lower bound is popped.
-    fringe: &'a mut (dyn Frontier<State = State>),
+    fringe: &'a mut (dyn Fringe<State = State>),
     /// This is a counter that tracks the number of nodes that have effectively
     /// been explored. That is, the number of nodes that have been popped from
     /// the fringe, and for which a restricted and relaxed mdd have been developed.
@@ -233,7 +233,7 @@ where State: Eq + Hash + Clone
         ranking: &'a (dyn StateRanking<State = State>),
         width: &'a (dyn WidthHeuristic<State>),
         cutoff: &'a (dyn Cutoff), 
-        fringe: &'a mut (dyn Frontier<State = State>),
+        fringe: &'a mut (dyn Fringe<State = State>),
     ) -> Self {
         Self::custom(problem, relaxation, ranking, width, CutsetType::LastExactLayer, cutoff, fringe)
     }
@@ -252,7 +252,7 @@ where
         width_heu: &'a (dyn WidthHeuristic<State>),
         cutset_type: CutsetType,
         cutoff: &'a (dyn Cutoff),
-        fringe: &'a mut (dyn Frontier<State = State>),
+        fringe: &'a mut (dyn Fringe<State = State>),
     ) -> Self {
         SequentialSolver {
             problem,
@@ -482,7 +482,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -505,7 +505,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -528,7 +528,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -552,7 +552,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -577,7 +577,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -599,7 +599,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -622,7 +622,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -645,7 +645,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -670,7 +670,7 @@ mod test_solver {
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
         let cutset = CutsetType::LastExactLayer;
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DD::custom(
             &problem,
             &relax,
@@ -707,7 +707,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DD::custom(
             &problem,
             &relax,
@@ -744,7 +744,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -783,7 +783,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -828,7 +828,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SequentialSolver::new(
             &problem,
             &relax,
@@ -851,7 +851,7 @@ mod test_solver {
         let ranking = KPRanking;
         let cutoff = NoCutoff;
         let width = NbUnassignedWitdh(problem.nb_variables());
-        let mut fringe = SimpleFrontier::new(MaxUB::new(&ranking));
+        let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SequentialSolver::new(
             &problem,
             &relax,

--- a/ddo/src/lib.rs
+++ b/ddo/src/lib.rs
@@ -397,8 +397,8 @@
 //! // 5. Decide of a cutoff heuristic (if you dont want to let the solver run for ever)
 //! let cutoff = NoCutoff; // might as well be a TimeBudget (or something else)
 //! 
-//! // 5. Create the solver frontier
-//! let mut frontier = SimpleFrontier::new(MaxUB::new(&heuristic));
+//! // 5. Create the solver fringe
+//! let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));
 //!  
 //! // 6. Instanciate your solver
 //! let mut solver = DefaultSolver::new(
@@ -407,7 +407,7 @@
 //!       &heuristic, 
 //!       &width, 
 //!       &cutoff, 
-//!       &mut frontier);
+//!       &mut fringe);
 //! 
 //! // 7. Maximize your objective function
 //! // the outcome provides the value of the best solution that was found for

--- a/py_ddo/examples/knapsack/knapsack.py
+++ b/py_ddo/examples/knapsack/knapsack.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     problem   = Knapsack(c, p, w)
     relax     = KnapsackRelax(problem)
     ranking   = KnapsackRanking()
-    result    = ddo.maximize(problem, relax, ranking, True, True, 100, 15)
+    result    = ddo.maximize(problem, relax, ranking, True, True, True, 100, 15)
     print("Duration:   {:.3f} seconds \nObjective:  {}\nUpper Bnd:  {}\nLower Bnd:  {}\nGap:        {}\nAborted:    {}\nSolution:   {}"
         .format(
             result.duration, 

--- a/py_ddo/examples/knapsack/knapsack.py
+++ b/py_ddo/examples/knapsack/knapsack.py
@@ -1,4 +1,5 @@
 import ddo
+import os
 
 class KnapsackState:
     '''
@@ -131,14 +132,17 @@ def read_instance(fname):
                 weights.append(int(b))
         return (capa, profits, weights)
 
+def get_path(instance):
+    dirname = os.path.dirname(__file__)
+    return os.path.join(dirname, "..", "..", "..", "resources", "knapsack", instance)
 
 if __name__ == "__main__":
-    instance  = "/Users/xgillard/Downloads/instances_01_KP(1)/large_scale/knapPI_3_100_1000_1"
-    (c, p, w) = read_instance(instance)
+    instance  = "f8_l-d_kp_23_10000"
+    (c, p, w) = read_instance(get_path(instance))
     problem   = Knapsack(c, p, w)
     relax     = KnapsackRelax(problem)
     ranking   = KnapsackRanking()
-    result    = ddo.maximize(problem, relax, ranking, True, 100, 15)
+    result    = ddo.maximize(problem, relax, ranking, True, True, 100, 15)
     print("Duration:   {:.3f} seconds \nObjective:  {}\nUpper Bnd:  {}\nLower Bnd:  {}\nGap:        {}\nAborted:    {}\nSolution:   {}"
         .format(
             result.duration, 

--- a/py_ddo/src/lib.rs
+++ b/py_ddo/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{time::{Duration, Instant}, hash::Hash, collections::HashMap};
 
-use ::ddo::{Problem, Cutoff, TimeBudget, NoCutoff, Frontier, NoDupFrontier, StateRanking, MaxUB, SimpleFrontier, WidthHeuristic, FixedWidth, NbUnassignedWitdh, Variable, Decision, Relaxation, SequentialSolver, Solver, Completion, DefaultMDD, CutsetType};
+use ::ddo::{Problem, Cutoff, TimeBudget, NoCutoff, Fringe, NoDupFringe, StateRanking, MaxUB, SimpleFringe, WidthHeuristic, FixedWidth, NbUnassignedWitdh, Variable, Decision, Relaxation, SequentialSolver, Solver, Completion, DefaultMDD, CutsetType};
 
 use pyo3::{prelude::*, types::{PyBool}};
 
@@ -60,7 +60,7 @@ fn maximize(
         let max_width = max_width(problem.nb_variables(), width);
         let cutset = cutset(lel);
         let cutoff = cutoff(timeout);
-        let mut fringe = frontier(dedup, &ranking);
+        let mut fringe = fringe(dedup, &ranking);
 
         let mut solver = SequentialSolver::<PyState, DefaultMDD<PyState>>::custom(
             &problem, 
@@ -102,11 +102,11 @@ fn cutoff(timeout: Option<u64>) -> Box<dyn Cutoff> {
     }
 }
 
-fn frontier<'a>(dedup: bool, ranking: &'a PyRanking<'a>) -> Box<dyn Frontier<State = PyState<'a>> + 'a> {
+fn fringe<'a>(dedup: bool, ranking: &'a PyRanking<'a>) -> Box<dyn Fringe<State = PyState<'a>> + 'a> {
     if dedup {
-        Box::new(NoDupFrontier::new(MaxUB::new(ranking)))
+        Box::new(NoDupFringe::new(MaxUB::new(ranking)))
     } else {
-        Box::new(SimpleFrontier::new(MaxUB::new(ranking)))
+        Box::new(SimpleFringe::new(MaxUB::new(ranking)))
     }
 }
 

--- a/py_ddo/src/lib.rs
+++ b/py_ddo/src/lib.rs
@@ -61,7 +61,7 @@ fn maximize(
         let cutset = cutset(lel);
         let cutoff = cutoff(timeout);
         let mut fringe = fringe(dedup, &ranking);
-        let mut barrier = EmptyBarrier{};
+        let barrier = EmptyBarrier::new();
 
         let mut solver = SequentialSolver::<PyState, DefaultMDD<PyState>>::custom(
             &problem, 
@@ -71,7 +71,7 @@ fn maximize(
             cutset,
             cutoff.as_ref(), 
             fringe.as_mut(),
-            &mut barrier,
+            &barrier,
         );
 
         let start = Instant::now();

--- a/py_ddo/src/lib.rs
+++ b/py_ddo/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{time::{Duration, Instant}, hash::Hash, collections::HashMap};
 
-use ::ddo::{Problem, Cutoff, TimeBudget, NoCutoff, Fringe, NoDupFringe, StateRanking, MaxUB, SimpleFringe, WidthHeuristic, FixedWidth, NbUnassignedWitdh, Variable, Decision, Relaxation, SequentialSolver, Solver, Completion, DefaultMDD, CutsetType};
+use ::ddo::{Problem, Cutoff, TimeBudget, NoCutoff, Fringe, NoDupFringe, StateRanking, MaxUB, SimpleFringe, WidthHeuristic, FixedWidth, NbUnassignedWitdh, Variable, Decision, Relaxation, SequentialSolver, Solver, Completion, DefaultMDD, CutsetType, EmptyBarrier};
 
 use pyo3::{prelude::*, types::{PyBool}};
 
@@ -61,6 +61,7 @@ fn maximize(
         let cutset = cutset(lel);
         let cutoff = cutoff(timeout);
         let mut fringe = fringe(dedup, &ranking);
+        let mut barrier = EmptyBarrier{};
 
         let mut solver = SequentialSolver::<PyState, DefaultMDD<PyState>>::custom(
             &problem, 
@@ -70,6 +71,7 @@ fn maximize(
             cutset,
             cutoff.as_ref(), 
             fringe.as_mut(),
+            &mut barrier,
         );
 
         let start = Instant::now();


### PR DESCRIPTION
- Addition of a barrier to the solvers and in the compilation input for the DDs
- Ability to choose between LEL and frontier cutset -> renamed all 'frontier' occurrences to 'fringe' when used to refer to the branch-and-bound queue
- Trait Barrier that can have multiple implementations (currently 2: the EmptyBarrier to disable the behavior and the SimpleBarrier that uses RwLocks)
- Added a depth field to DD nodes and to subproblems so the barrier (when split by depth) should be compatible with long arcs