### PR TITLE
Remove unnecessary rub computation

### DIFF
--- a/ddo/src/implementation/mdd/vector_based.rs
+++ b/ddo/src/implementation/mdd/vector_based.rs
@@ -331,15 +331,7 @@ where
                 CompilationType::Relaxed => {
                     if curr_l.len() > input.max_width && depth > root_depth + 1 {
                         if CUTSET_TYPE == LAST_EXACT_LAYER {
-                            let was_lel = self.maybe_save_lel();
-                            //
-                            if was_lel {
-                                for id in curr_l.iter() {
-                                    let rub = input.relaxation.fast_upper_bound(self.nodes[id.0].state.as_ref());
-                                    self.nodes[id.0].rub = rub;
-                                }
-                            }
-                            //
+                            self.maybe_save_lel();
                         }
                         self.relax(input, &mut curr_l)
                     }
@@ -553,7 +545,7 @@ where
                     self.nodes[merged_id.0].best = Some(new_eid);
                     self.nodes[merged_id.0].value = new_value;
                 }
-
+                
                 edge_id = edge.next;
             }
         }


### PR DESCRIPTION
It seems to me that this RUB is not needed. The RUB values are not used in `relax` and the RUB is computed again before expanding each node in the loop just below.
```
for node_id in curr_l.iter() {
    let state = self.nodes[node_id.0].state.clone();
    let rub = input.relaxation.fast_upper_bound(state.as_ref());
    ...
```