### PR TITLE
Fix API typos

### DIFF
--- a/ddo/examples/alp/main.rs
+++ b/ddo/examples/alp/main.rs
@@ -58,7 +58,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 /// An utility function to return a cutoff heuristic that can either be a time budget policy

--- a/ddo/examples/alp/tests.rs
+++ b/ddo/examples/alp/tests.rs
@@ -40,7 +40,7 @@ pub fn solve_id(id: &str) -> isize {
     let relaxation = AlpRelax::new(problem.clone());
     let ranking = AlpRanking;
 
-    let width = NbUnassignedWitdh(problem.nb_variables());
+    let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = SimpleDominanceChecker::new(AlpDominance);
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));

--- a/ddo/examples/golomb/main.rs
+++ b/ddo/examples/golomb/main.rs
@@ -219,7 +219,7 @@ fn max_width<T>(nb_vars: usize, w: Option<usize>) -> Box<dyn WidthHeuristic<T> +
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(nb_vars))
+        Box::new(NbUnassignedWidth(nb_vars))
     }
 }
 

--- a/ddo/examples/golomb/main.rs
+++ b/ddo/examples/golomb/main.rs
@@ -177,8 +177,8 @@ impl Relaxation for GolombRelax<'_> {
 /// solver is a `StateRanking`. This is an heuristic which is used to select the most
 /// and least promising nodes as a means to only delete/merge the *least* promising nodes
 /// when compiling restricted and relaxed DDs.
-pub struct Golombranking;
-impl StateRanking for Golombranking {
+pub struct GolombRanking;
+impl StateRanking for GolombRanking {
     type State = GolombState;
 
     fn compare(&self, a: &Self::State, b: &Self::State) -> std::cmp::Ordering {
@@ -229,7 +229,7 @@ fn main() {
     let args = Args::parse();
     let problem = Golomb::new(args.size);
     let relaxation = GolombRelax{pb: &problem};
-    let heuristic = Golombranking;
+    let heuristic = GolombRanking;
     let width = max_width(problem.nb_variables(), args.width);
     let dominance = EmptyDominanceChecker::default();
     let cutoff = TimeBudget::new(Duration::from_secs(args.timeout));//NoCutoff;

--- a/ddo/examples/golomb/tests.rs
+++ b/ddo/examples/golomb/tests.rs
@@ -27,7 +27,7 @@ pub fn solve_golomb(n: usize) -> isize {
     let problem = Golomb::new(n);
     let relaxation = GolombRelax{pb: &problem};
     let heuristic = Golombranking;
-    let width = NbUnassignedWitdh(problem.nb_variables());
+    let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = EmptyDominanceChecker::default();
     let cutoff = NoCutoff;
     let mut fringe = SimpleFringe::new(MaxUB::new(&heuristic));

--- a/ddo/examples/golomb/tests.rs
+++ b/ddo/examples/golomb/tests.rs
@@ -20,13 +20,13 @@
 //! This module is meant to tests the correctness of our golomb example
 use ddo::*;
 
-use crate::{Golomb, Golombranking, GolombRelax};
+use crate::{Golomb, GolombRanking, GolombRelax};
 
 pub fn solve_golomb(n: usize) -> isize {
 
     let problem = Golomb::new(n);
     let relaxation = GolombRelax{pb: &problem};
-    let heuristic = Golombranking;
+    let heuristic = GolombRanking;
     let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = EmptyDominanceChecker::default();
     let cutoff = NoCutoff;

--- a/ddo/examples/knapsack/main.rs
+++ b/ddo/examples/knapsack/main.rs
@@ -305,7 +305,7 @@ fn max_width<T>(nb_vars: usize, w: Option<usize>) -> Box<dyn WidthHeuristic<T> +
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(nb_vars))
+        Box::new(NbUnassignedWidth(nb_vars))
     }
 }
 

--- a/ddo/examples/knapsack/tests.rs
+++ b/ddo/examples/knapsack/tests.rs
@@ -41,7 +41,7 @@ pub fn solve_id(id: &str) -> isize {
     let relaxation = KPRelax{pb: &problem};
     let ranking = KPRanking;
 
-    let width = NbUnassignedWitdh(problem.nb_variables());
+    let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = SimpleDominanceChecker::new(KPDominance);
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));

--- a/ddo/examples/lcs/main.rs
+++ b/ddo/examples/lcs/main.rs
@@ -60,7 +60,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 /// An utility function to return a cutoff heuristic that can either be a time budget policy

--- a/ddo/examples/max2sat/main.rs
+++ b/ddo/examples/max2sat/main.rs
@@ -82,7 +82,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 

--- a/ddo/examples/max2sat/tests.rs
+++ b/ddo/examples/max2sat/tests.rs
@@ -41,7 +41,7 @@ pub fn solve_id(id: &str) -> isize {
     let relaxation = Max2SatRelax(&problem);
     let ranking = Max2SatRanking;
 
-    let width = NbUnassignedWitdh(problem.nb_variables());
+    let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = EmptyDominanceChecker::default();
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));

--- a/ddo/examples/mcp/main.rs
+++ b/ddo/examples/mcp/main.rs
@@ -76,6 +76,6 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }

--- a/ddo/examples/mcp/tests.rs
+++ b/ddo/examples/mcp/tests.rs
@@ -43,7 +43,7 @@ pub fn solve_id(id: &str) -> isize {
     let relaxation = McpRelax::new(&problem);
     let ranking = McpRanking;
 
-    let width = NbUnassignedWitdh(problem.nb_variables());
+    let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = EmptyDominanceChecker::default();
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));

--- a/ddo/examples/misp/main.rs
+++ b/ddo/examples/misp/main.rs
@@ -323,7 +323,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 /// An utility function to return a cutoff heuristic that can either be a time budget policy

--- a/ddo/examples/misp/tests.rs
+++ b/ddo/examples/misp/tests.rs
@@ -42,7 +42,7 @@ pub fn solve_id(id: &str) -> isize {
     let relaxation = MispRelax {pb: &&problem};
     let ranking = MispRanking;
 
-    let width = NbUnassignedWitdh(problem.nb_variables());
+    let width = NbUnassignedWidth(problem.nb_variables());
     let dominance = EmptyDominanceChecker::default();
     let cutoff = NoCutoff;
     let mut fringe = NoDupFringe::new(MaxUB::new(&ranking));

--- a/ddo/examples/psp/main.rs
+++ b/ddo/examples/psp/main.rs
@@ -69,7 +69,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 /// An utility function to return a cutoff heuristic that can either be a time budget policy

--- a/ddo/examples/srflp/main.rs
+++ b/ddo/examples/srflp/main.rs
@@ -64,7 +64,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<Srfl
     if let Some(w) = w {
         Box::new(SrflpWidth::new(p.nb_variables(), w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 /// An utility function to return a cutoff heuristic that can either be a time budget policy

--- a/ddo/examples/talentsched/main.rs
+++ b/ddo/examples/talentsched/main.rs
@@ -58,7 +58,7 @@ fn max_width<P: Problem>(p: &P, w: Option<usize>) -> Box<dyn WidthHeuristic<P::S
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(p.nb_variables()))
+        Box::new(NbUnassignedWidth(p.nb_variables()))
     }
 }
 /// An utility function to return a cutoff heuristic that can either be a time budget policy

--- a/ddo/src/implementation/heuristics/width.rs
+++ b/ddo/src/implementation/heuristics/width.rs
@@ -250,7 +250,7 @@ impl <X> WidthHeuristic<X> for FixedWidth {
 /// #     profit  : vec![60, 100, 120],
 /// #     weight  : vec![10,  20,  30]
 /// };
-/// let heuristic = NbUnassignedWitdh(problem.nb_variables());
+/// let heuristic = NbUnassignedWidth(problem.nb_variables());
 /// let subproblem= SubProblem {
 /// #    state: Arc::new(KnapsackState{depth: 3, capacity: 2}), 
 /// #    value: 5, 
@@ -267,7 +267,7 @@ impl <X> WidthHeuristic<X> for FixedWidth {
 /// ```
 /// 
 /// # Typical usage example
-/// Typically, you will only ever create a NbUnassignedWitdh policy when instanciating 
+/// Typically, you will only ever create a NbUnassignedWidth policy when instanciating 
 /// your solver. The following example shows how you create a solver that imposes
 /// a maximum layer width of one node per unassigned variable.
 /// 
@@ -388,14 +388,14 @@ impl <X> WidthHeuristic<X> for FixedWidth {
 ///       &problem, 
 ///       &relaxation, 
 ///       &heuristic, 
-///       &NbUnassignedWitdh(problem.nb_variables()),
+///       &NbUnassignedWidth(problem.nb_variables()),
 ///       &dominance,
 ///       &cutoff, 
 ///       &mut fringe);
 /// ```
 #[derive(Default, Debug, Copy, Clone)]
-pub struct NbUnassignedWitdh(pub usize);
-impl <X> WidthHeuristic<X> for NbUnassignedWitdh {
+pub struct NbUnassignedWidth(pub usize);
+impl <X> WidthHeuristic<X> for NbUnassignedWidth {
     fn max_width(&self, x: &SubProblem<X>) -> usize {
         self.0 - x.path.len()
     }
@@ -489,7 +489,7 @@ impl <X> WidthHeuristic<X> for NbUnassignedWitdh {
 /// #     profit  : vec![60, 100, 120],
 /// #     weight  : vec![10,  20,  30]
 /// };
-/// let heuristic = Times(5, NbUnassignedWitdh(problem.nb_variables()));
+/// let heuristic = Times(5, NbUnassignedWidth(problem.nb_variables()));
 /// let subproblem= SubProblem {
 /// #    state: Arc::new(KnapsackState{depth: 3, capacity: 2}), 
 /// #    value: 5, 
@@ -627,7 +627,7 @@ impl <X> WidthHeuristic<X> for NbUnassignedWitdh {
 ///       &problem, 
 ///       &relaxation, 
 ///       &heuristic, 
-///       &Times(5, NbUnassignedWitdh(problem.nb_variables())),
+///       &Times(5, NbUnassignedWidth(problem.nb_variables())),
 ///       &dominance,
 ///       &cutoff, 
 ///       &mut fringe);
@@ -729,7 +729,7 @@ impl <S, X: WidthHeuristic<S>> WidthHeuristic<S> for Times<X> {
 /// #     profit  : vec![60, 100, 120],
 /// #     weight  : vec![10,  20,  30]
 /// };
-/// let heuristic = DivBy(2, NbUnassignedWitdh(problem.nb_variables()));
+/// let heuristic = DivBy(2, NbUnassignedWidth(problem.nb_variables()));
 /// let subproblem= SubProblem {
 /// #    state: Arc::new(KnapsackState{depth: 3, capacity: 2}), 
 /// #    value: 5, 
@@ -866,7 +866,7 @@ impl <S, X: WidthHeuristic<S>> WidthHeuristic<S> for Times<X> {
 ///       &problem, 
 ///       &relaxation, 
 ///       &heuristic, 
-///       &DivBy(2, NbUnassignedWitdh(problem.nb_variables())),
+///       &DivBy(2, NbUnassignedWidth(problem.nb_variables())),
 ///       &dominance,
 ///       &cutoff, 
 ///       &mut fringe);
@@ -890,7 +890,7 @@ mod test_nbunassigned {
     #[test]
     fn non_empty() {
         // assume a problem with 5 variables
-        let heu = NbUnassignedWitdh(5); 
+        let heu = NbUnassignedWidth(5); 
         let sub = SubProblem {
             state: Arc::new('a'),
             value: 10,
@@ -902,7 +902,7 @@ mod test_nbunassigned {
     }
     #[test]
     fn all() {
-        let heu = NbUnassignedWitdh(5); 
+        let heu = NbUnassignedWidth(5); 
         let sub = SubProblem {
             state: Arc::new('a'),
             value: 10,
@@ -915,7 +915,7 @@ mod test_nbunassigned {
     #[test]
     fn empty() {
         // assume a problem with 5 variables
-        let heu = NbUnassignedWitdh(5); 
+        let heu = NbUnassignedWidth(5); 
         let sub = SubProblem {
             state: Arc::new('a'),
             value: 10,

--- a/ddo/src/implementation/solver/parallel.rs
+++ b/ddo/src/implementation/solver/parallel.rs
@@ -663,7 +663,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -689,7 +689,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -715,7 +715,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(
@@ -742,7 +742,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(
@@ -770,7 +770,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -795,7 +795,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -824,7 +824,7 @@ mod test_solver {
         let relax = KPRelax {pb: &&problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DD::custom(
@@ -851,7 +851,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -877,7 +877,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -904,7 +904,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(
@@ -943,7 +943,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdFc::custom(
@@ -982,7 +982,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(
@@ -1025,7 +1025,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdFc::custom(
@@ -1068,7 +1068,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(
@@ -1111,7 +1111,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdFc::custom(
@@ -1154,7 +1154,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(
@@ -1202,7 +1202,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = DdLel::custom(
@@ -1228,7 +1228,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = DdLel::custom(

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -548,7 +548,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -573,7 +573,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -598,7 +598,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqSolver::new(
@@ -624,7 +624,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqSolver::new(
@@ -651,7 +651,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -675,7 +675,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -700,7 +700,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -725,7 +725,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -751,7 +751,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqSolver::custom(
@@ -789,7 +789,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqBarrierSolver::custom(
@@ -827,7 +827,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqSolver::new(
@@ -869,7 +869,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqBarrierSolver::new(
@@ -911,7 +911,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqSolver::new(
@@ -958,7 +958,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let solver = SeqSolver::new(
@@ -983,7 +983,7 @@ mod test_solver {
         let relax = KPRelax {pb: &problem};
         let ranking = KPRanking;
         let cutoff = NoCutoff;
-        let width = NbUnassignedWitdh(problem.nb_variables());
+        let width = NbUnassignedWidth(problem.nb_variables());
         let dominance = EmptyDominanceChecker::default();
         let mut fringe = SimpleFringe::new(MaxUB::new(&ranking));
         let mut solver = SeqSolver::new(

--- a/py_ddo/src/lib.rs
+++ b/py_ddo/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{time::{Duration, Instant}, hash::Hash, collections::HashMap};
 
-use ::ddo::{Problem, Cutoff, TimeBudget, NoCutoff, Fringe, NoDupFringe, StateRanking, MaxUB, SimpleFringe, WidthHeuristic, FixedWidth, NbUnassignedWitdh, Variable, Decision, Relaxation, Solver, Completion, SeqNoBarrierSolverLel, SeqBarrierSolverLel, SeqBarrierSolverFc, SeqNoBarrierSolverFc};
+use ::ddo::{Problem, Cutoff, TimeBudget, NoCutoff, Fringe, NoDupFringe, StateRanking, MaxUB, SimpleFringe, WidthHeuristic, FixedWidth, NbUnassignedWidth, Variable, Decision, Relaxation, Solver, Completion, SeqNoBarrierSolverLel, SeqBarrierSolverLel, SeqBarrierSolverFc, SeqNoBarrierSolverFc};
 
 use pyo3::{prelude::*, types::{PyBool}};
 
@@ -139,7 +139,7 @@ fn max_width<'a>(n: usize, w: Option<usize>) -> Box<dyn WidthHeuristic<PyState<'
     if let Some(w) = w {
         Box::new(FixedWidth(w))
     } else {
-        Box::new(NbUnassignedWitdh(n))
+        Box::new(NbUnassignedWidth(n))
     }
 }
 


### PR DESCRIPTION
Renames two types in the public API, fixing typos:

- `NbUnassignedWitdh` -> `NbUnassignedWidth`
- `Golombranking` -> `GolombRanking`