### PR TITLE
Fix signature of `explored` in trait Solver to fix compile error

### DIFF
--- a/ddo/src/abstraction/solver.rs
+++ b/ddo/src/abstraction/solver.rs
@@ -93,5 +93,5 @@ pub trait Solver {
     }
 
     /// Returns the number of nodes that have been explored during the search.
-    fn explored() -> usize;
+    fn explored(&self) -> usize;
 }


### PR DESCRIPTION
Fascinating crate!

I'm planning to bring some major improvements, including:

* progress logging like some ILP solvers such as CBC or SCIP
* improvement in favor of very large (1000+ variables) problems
    * I found that each `SubProblem` contains the entire path (decided variables and values, which are 16 bytes each) from root to the current node, which chokes the memory very badly and also considerably slows down performance. I believe that keeping just a link to the previous subproblem that produced that node should be enough, as the path can be reconstructed by following the link and rebuilding the relaxed BDD. (This is definitely more computation, but it should only be triggered when the objective value is improved, which is arguably rare.) If a problem needs to really look at the entire path for its heuristics, the user can opt into that by including it in `State`.
    * I also found that the threading behavior becomes poor after a while (I saw only ~35% CPU utilization). I see a lot of critical section accesses in the code, which can definitely be improved.

But the master branch not even compiling is a no-go, so here is a fix for that :)