### PR TITLE
Change some traits' associated types to type parameters

### DIFF
--- a/ddo/src/abstraction/cache.rs
+++ b/ddo/src/abstraction/cache.rs
@@ -24,12 +24,10 @@ use crate::{Threshold, SubProblem, Problem};
 /// This trait abstracts away the implementation details of the solver cache.
 /// That is, a Cache represents the data structure that stores thresholds that
 /// condition the re-exploration of nodes with a state already reached previously.
-pub trait Cache {
-    type State;
-
+pub trait Cache<State> {
     /// Returns true if the subproblem still must be explored,
     /// given the thresholds contained in the cache.
-    fn must_explore(&self, subproblem: &SubProblem<Self::State>) -> bool {
+    fn must_explore(&self, subproblem: &SubProblem<State>) -> bool {
         let threshold = self.get_threshold(subproblem.state.as_ref(), subproblem.depth);
         if let Some(threshold) = threshold {
             subproblem.value > threshold.value || (subproblem.value == threshold.value && !threshold.explored)
@@ -39,13 +37,13 @@ pub trait Cache {
     }
 
     /// Prepare the cache to be used with the given problem
-    fn initialize(&mut self, problem: &dyn Problem<State = Self::State>);
+    fn initialize(&mut self, problem: &dyn Problem<State = State>);
 
     /// Returns the threshold currently associated with the given state, if any.
-    fn get_threshold(&self, state: &Self::State, depth: usize) -> Option<Threshold>;
+    fn get_threshold(&self, state: &State, depth: usize) -> Option<Threshold>;
 
     /// Updates the threshold associated with the given state, only if it is increased.
-    fn update_threshold(&self, state: Arc<Self::State>, depth: usize, value: isize, explored: bool);
+    fn update_threshold(&self, state: Arc<State>, depth: usize, value: isize, explored: bool);
 
     /// Removes all thresholds associated with states at the given depth.
     fn clear_layer(&self, depth: usize);

--- a/ddo/src/abstraction/dominance.rs
+++ b/ddo/src/abstraction/dominance.rs
@@ -110,18 +110,16 @@ pub struct DominanceCheckResult {
     pub threshold: Option<isize>,
 }
 
-pub trait DominanceChecker {
-    type State;
-    
+pub trait DominanceChecker<State> {
     /// Removes all entries associated with states at the given depth.
     fn clear_layer(&self, depth: usize);
 
     /// Returns true if the state is dominated by a stored one, and a potential
     /// pruning threshold, and inserts the (key, value) pair otherwise
-    fn is_dominated_or_insert(&self, state: Arc<Self::State>, depth: usize, value: isize) -> DominanceCheckResult;
+    fn is_dominated_or_insert(&self, state: Arc<State>, depth: usize, value: isize) -> DominanceCheckResult;
 
     /// Comparator to order states by increasing value, regardless of their key
-    fn cmp(&self, a: &Self::State, val_a: isize, b: &Self::State, val_b: isize) -> Ordering;
+    fn cmp(&self, a: &State, val_a: isize, b: &State, val_b: isize) -> Ordering;
     
 }
 

--- a/ddo/src/abstraction/fringe.rs
+++ b/ddo/src/abstraction/fringe.rs
@@ -23,17 +23,15 @@ use crate::SubProblem;
 /// This trait abstracts away the implementation details of the solver fringe.
 /// That is, a Fringe represents the global priority queue which stores all 
 /// the nodes remaining to explore.
-pub trait Fringe {
-    type State;
-
+pub trait Fringe<State> {
     /// This is how you push a node onto the fringe.
-    fn push(&mut self, node: SubProblem<Self::State>);
+    fn push(&mut self, node: SubProblem<State>);
     /// This method yields the most promising node from the fringe.
     /// # Note:
     /// The solvers rely on the assumption that a fringe will pop nodes in
     /// descending upper bound order. Hence, it is a requirement for any fringe
     /// implementation to enforce that requirement.
-    fn pop(&mut self) -> Option<SubProblem<Self::State>>;
+    fn pop(&mut self) -> Option<SubProblem<State>>;
     /// This method clears the fringe: it removes all nodes from the queue.
     fn clear(&mut self);
     /// Yields the length of the queue.

--- a/ddo/src/abstraction/heuristics.rs
+++ b/ddo/src/abstraction/heuristics.rs
@@ -85,15 +85,11 @@ pub trait StateRanking {
 /// sub-problems on the solver fringe. This order is used by the framework 
 /// as a means to impose a given ordering on the nodes that are popped from
 /// the solver fringe.
-pub trait SubProblemRanking {
-    /// As is the case for `Problem` and `Relaxation`, a `SubProblemRanking` 
-    /// must tell the kind of states it is able to operate on.
-    type State;
-
+pub trait SubProblemRanking<State> {
     /// This method compares two sub-problems and determines which is the one 
     /// that needs to be popped off the fringe first. In this ordering, greater
     /// means more likely to be popped first.
-    fn compare(&self, a: &SubProblem<Self::State>, b: &SubProblem<Self::State>) -> Ordering;
+    fn compare(&self, a: &SubProblem<State>, b: &SubProblem<State>) -> Ordering;
 }
 
 /// This trait encapsulates a criterion (external to the solver) which imposes

--- a/ddo/src/abstraction/mdd.rs
+++ b/ddo/src/abstraction/mdd.rs
@@ -66,7 +66,7 @@ pub struct CompilationInput<'a, State> {
     /// The best known lower bound at the time when the dd is being compiled
     pub best_lb: isize,
     /// Data structure containing info about past compilations used to prune the search
-    pub cache: &'a dyn Cache<State = State>,
+    pub cache: &'a dyn Cache<State>,
     pub dominance: &'a dyn DominanceChecker<State = State>,
 }
 

--- a/ddo/src/abstraction/mdd.rs
+++ b/ddo/src/abstraction/mdd.rs
@@ -67,7 +67,7 @@ pub struct CompilationInput<'a, State> {
     pub best_lb: isize,
     /// Data structure containing info about past compilations used to prune the search
     pub cache: &'a dyn Cache<State>,
-    pub dominance: &'a dyn DominanceChecker<State = State>,
+    pub dominance: &'a dyn DominanceChecker<State>,
 }
 
 /// This trait describes the operations that can be expected from an abstract

--- a/ddo/src/abstraction/mdd.rs
+++ b/ddo/src/abstraction/mdd.rs
@@ -72,14 +72,10 @@ pub struct CompilationInput<'a, State> {
 
 /// This trait describes the operations that can be expected from an abstract
 /// decision diagram regardless of the way it is implemented.
-pub trait DecisionDiagram {
-    /// This associated type corresponds to the `State` type of the problems 
-    /// that can be solved when using this DD.
-    type State;
-
+pub trait DecisionDiagram<State> {
     /// This method provokes the compilation of the DD based on the given 
     /// compilation input (compilation type, and root subproblem)
-    fn compile(&mut self, input: &CompilationInput<Self::State>) 
+    fn compile(&mut self, input: &CompilationInput<State>) 
         -> Result<Completion, Reason>;
     /// Returns true iff the DD which has been compiled is an exact DD.
     fn is_exact(&self) -> bool;
@@ -110,5 +106,5 @@ pub trait DecisionDiagram {
     /// this method will be called at most once per relaxed DD compilation.
     fn drain_cutset<F>(&mut self, func: F)
     where
-        F: FnMut(SubProblem<Self::State>);
+        F: FnMut(SubProblem<State>);
 }

--- a/ddo/src/implementation/cache/empty.rs
+++ b/ddo/src/implementation/cache/empty.rs
@@ -30,33 +30,31 @@ use crate::*;
 
 /// Dummy implementation of Cache with no information stored at all.
 #[derive(Debug, Clone, Copy)]
-pub struct EmptyCache<T> {
-    phantom: PhantomData<T>,
+pub struct EmptyCache<State> {
+    phantom: PhantomData<State>,
 }
-impl <T> Default for EmptyCache<T> {
+impl <State> Default for EmptyCache<State> {
     fn default() -> Self {
         EmptyCache { phantom: Default::default() }
     }
 }
-impl <T> EmptyCache<T> {
+impl <State> EmptyCache<State> {
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-impl<T> Cache for EmptyCache<T> {
-    type State = T;
+impl<State> Cache<State> for EmptyCache<State> {
+    #[inline(always)]
+    fn initialize(&mut self, _: &dyn Problem<State = State>) {}
 
     #[inline(always)]
-    fn initialize(&mut self, _: &dyn Problem<State = Self::State>) {}
-
-    #[inline(always)]
-    fn get_threshold(&self, _: &T, _: usize) -> Option<Threshold> {
+    fn get_threshold(&self, _: &State, _: usize) -> Option<Threshold> {
         None
     }
 
     #[inline(always)]
-    fn update_threshold(&self, _: Arc<T>, _: usize, _: isize, _: bool) {}
+    fn update_threshold(&self, _: Arc<State>, _: usize, _: isize, _: bool) {}
 
     #[inline(always)]
     fn clear_layer(&self, _: usize) {}
@@ -65,7 +63,7 @@ impl<T> Cache for EmptyCache<T> {
     fn clear(&self) {}
 
     #[inline(always)]
-    fn must_explore(&self, _: &SubProblem<Self::State>) -> bool {
+    fn must_explore(&self, _: &SubProblem<State>) -> bool {
         true
     }
 }

--- a/ddo/src/implementation/dominance/empty.rs
+++ b/ddo/src/implementation/dominance/empty.rs
@@ -21,27 +21,25 @@ use std::{marker::PhantomData, cmp::Ordering, sync::Arc};
 use crate::{DominanceChecker, DominanceCheckResult};
 
 /// Implementation of a dominance checker that never detects any dominance relation
-pub struct EmptyDominanceChecker<T>
+pub struct EmptyDominanceChecker<State>
 {
-    _phantom: PhantomData<T>,
+    _phantom: PhantomData<State>,
 }
 
-impl<T> Default for EmptyDominanceChecker<T> {
+impl<State> Default for EmptyDominanceChecker<State> {
     fn default() -> Self {
         Self { _phantom: Default::default() }
     }
 }
 
-impl<T> DominanceChecker for EmptyDominanceChecker<T> {
-    type State = T;
-
+impl<State> DominanceChecker<State> for EmptyDominanceChecker<State> {
     fn clear_layer(&self, _: usize) {}
 
-    fn is_dominated_or_insert(&self, _: Arc<Self::State>, _: usize, _: isize) -> DominanceCheckResult {
+    fn is_dominated_or_insert(&self, _: Arc<State>, _: usize, _: isize) -> DominanceCheckResult {
         DominanceCheckResult { dominated: false, threshold: None }
     }
 
-    fn cmp(&self, _: &Self::State, _: isize, _: &Self::State, _: isize) -> Ordering {
+    fn cmp(&self, _: &State, _: isize, _: &State, _: isize) -> Ordering {
         Ordering::Equal
     }
 }

--- a/ddo/src/implementation/dominance/simple.rs
+++ b/ddo/src/implementation/dominance/simple.rs
@@ -57,18 +57,16 @@ where
     }
 }
 
-impl<D> DominanceChecker for SimpleDominanceChecker<D> 
+impl<D> DominanceChecker<D::State> for SimpleDominanceChecker<D> 
 where
     D: Dominance,
     D::Key: Eq + PartialEq + Hash,
 {
-    type State = D::State;
-
     fn clear_layer(&self, depth: usize) {
         self.data[depth].clear();
     }
 
-    fn is_dominated_or_insert(&self, state: Arc<Self::State>, depth: usize, value: isize) -> DominanceCheckResult {
+    fn is_dominated_or_insert(&self, state: Arc<D::State>, depth: usize, value: isize) -> DominanceCheckResult {
         if let Some(key) = self.dominance.get_key(state.clone()) {
             match self.data[depth].entry(key) {
                 Entry::Occupied(mut e) => {
@@ -110,7 +108,7 @@ where
         }
     }
 
-    fn cmp(&self, a: &Self::State, val_a: isize, b: &Self::State, val_b: isize) -> Ordering {
+    fn cmp(&self, a: &D::State, val_a: isize, b: &D::State, val_b: isize) -> Ordering {
         self.dominance.cmp(a, val_a, b, val_b)
     }
 }

--- a/ddo/src/implementation/fringe/no_duplicate.rs
+++ b/ddo/src/implementation/fringe/no_duplicate.rs
@@ -68,13 +68,11 @@ where
     recycle_bin: Vec<NodeId>,
 }
 
-impl<O> Fringe for NoDupFringe<O>
+impl<O> Fringe<O::State> for NoDupFringe<O>
 where
     O: SubProblemRanking,
     O::State: Eq + Hash + Clone,
 {
-    type State = O::State;
-
     /// Pushes one node onto the heap while ensuring that only one copy of the
     /// node (identified by its state) is kept in the heap.
     ///
@@ -141,7 +139,7 @@ where
 
     /// Pops the best node out of the heap. Here, the best is defined as the
     /// node having the best upper bound, with the longest `value`.
-    fn pop(&mut self) -> Option<SubProblem<Self::State>> {
+    fn pop(&mut self) -> Option<SubProblem<O::State>> {
         if self.is_empty() {
             return None;
         }

--- a/ddo/src/implementation/fringe/simple.rs
+++ b/ddo/src/implementation/fringe/simple.rs
@@ -32,21 +32,27 @@ use crate::*;
 /// solvers. Hence, you don't need to take any action in order to use the
 /// `SimpleFringe`.
 /// 
-pub struct SimpleFringe<O: SubProblemRanking> {
-    heap: BinaryHeap<SubProblem<O::State>, CompareSubProblem<O>>
+pub struct SimpleFringe<State, Ranking> where
+    Ranking: SubProblemRanking<State>
+{
+    heap: BinaryHeap<SubProblem<State>, CompareSubProblem<State, Ranking>>
 }
-impl <O> SimpleFringe<O> where O: SubProblemRanking {
+impl <State, Ranking> SimpleFringe<State, Ranking> where
+    Ranking: SubProblemRanking<State>
+{
     /// This creates a new simple fringe which uses a custom fringe order.
-    pub fn new(o: O) -> Self {
-        Self{ heap: BinaryHeap::from_vec_cmp(vec![], CompareSubProblem::new(o)) }
+    pub fn new(ranking: Ranking) -> Self {
+        Self{ heap: BinaryHeap::from_vec_cmp(vec![], CompareSubProblem::new(ranking)) }
     }
 }
-impl <O> Fringe<O::State> for SimpleFringe<O> where O: SubProblemRanking {
-    fn push(&mut self, node: SubProblem<O::State>) {
+impl <State, Ranking> Fringe<State> for SimpleFringe<State, Ranking>
+where Ranking: SubProblemRanking<State>
+{
+    fn push(&mut self, node: SubProblem<State>) {
         self.heap.push(node)
     }
 
-    fn pop(&mut self) -> Option<SubProblem<O::State>> {
+    fn pop(&mut self) -> Option<SubProblem<State>> {
         self.heap.pop()
     }
 

--- a/ddo/src/implementation/fringe/simple.rs
+++ b/ddo/src/implementation/fringe/simple.rs
@@ -41,14 +41,12 @@ impl <O> SimpleFringe<O> where O: SubProblemRanking {
         Self{ heap: BinaryHeap::from_vec_cmp(vec![], CompareSubProblem::new(o)) }
     }
 }
-impl <O> Fringe for SimpleFringe<O> where O: SubProblemRanking {
-    type State = O::State;
-    
-    fn push(&mut self, node: SubProblem<Self::State>) {
+impl <O> Fringe<O::State> for SimpleFringe<O> where O: SubProblemRanking {
+    fn push(&mut self, node: SubProblem<O::State>) {
         self.heap.push(node)
     }
 
-    fn pop(&mut self) -> Option<SubProblem<Self::State>> {
+    fn pop(&mut self) -> Option<SubProblem<O::State>> {
         self.heap.pop()
     }
 

--- a/ddo/src/implementation/heuristics/subproblem_ranking.rs
+++ b/ddo/src/implementation/heuristics/subproblem_ranking.rs
@@ -80,9 +80,7 @@ impl <'a, O: StateRanking> MaxUB<'a, O> {
         Self(x)
     }
 }
-impl<O: StateRanking> SubProblemRanking for MaxUB<'_, O> {
-    type State = O::State;
-
+impl<O: StateRanking> SubProblemRanking<O::State> for MaxUB<'_, O> {
     fn compare(&self, l: &SubProblem<O::State>, r: &SubProblem<O::State>) -> Ordering {
         l.ub.cmp(&r.ub)
             .then_with(|| l.value.cmp(&r.value))

--- a/ddo/src/implementation/mdd/clean.rs
+++ b/ddo/src/implementation/mdd/clean.rs
@@ -34,9 +34,9 @@ struct LayerId(usize);
 
 /// Represents an effective node from the decision diagram
 #[derive(Debug, Clone)]
-struct Node<T> {
+struct Node<State> {
     /// The state associated to this node
-    state: Arc<T>,
+    state: Arc<State>,
     /// The length of the longest path between the problem root and this
     /// specific node
     value_top: isize,
@@ -112,9 +112,9 @@ struct Layer {
 /// - Relaxed: either the last exact layer of the frontier cut-set can be chosen
 ///            within the CompilationInput
 #[derive(Debug, Clone)]
-pub struct Mdd<T, const CUTSET_TYPE: CutsetType>
+pub struct Mdd<State, const CUTSET_TYPE: CutsetType>
 where
-    T: Eq + PartialEq + Hash + Clone,
+    State: Eq + PartialEq + Hash + Clone,
 {
     /// This vector stores the information about the structure of all the layers
     /// in this decision diagram
@@ -122,7 +122,7 @@ where
     /// All the nodes composing this decision diagram. The vector comprises 
     /// nodes from all layers in the DD. A nice property is that all nodes
     /// belonging to one same layer form a sequence in the ‘nodes‘ vector.
-    nodes: Vec<Node<T>>,
+    nodes: Vec<Node<State>>,
     /// This vector stores the information about all edges connecting the nodes 
     /// of the decision diagram.
     edges: Vec<Edge>,
@@ -140,7 +140,7 @@ where
     /// The rationale being that two transitions to the same state in the same
     /// layer should lead to the same node. This indexation helps ensuring 
     /// the uniqueness constraint in amortized O(1).
-    next_l: FxHashMap<Arc<T>, NodeId>,
+    next_l: FxHashMap<Arc<State>, NodeId>,
     /// The depth of the layer currently being expanded
     curr_depth: usize,
 
@@ -219,22 +219,20 @@ macro_rules! append_edge_to {
     };
 }
 
-impl<T, const CUTSET_TYPE: CutsetType> Default for Mdd<T, {CUTSET_TYPE}>
+impl<State, const CUTSET_TYPE: CutsetType> Default for Mdd<State, {CUTSET_TYPE}>
 where
-    T: Eq + PartialEq + Hash + Clone,
+    State: Eq + PartialEq + Hash + Clone,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T, const CUTSET_TYPE: CutsetType> DecisionDiagram for Mdd<T, {CUTSET_TYPE}>
+impl<State, const CUTSET_TYPE: CutsetType> DecisionDiagram<State> for Mdd<State, {CUTSET_TYPE}>
 where
-    T: Eq + PartialEq + Hash + Clone,
+    State: Eq + PartialEq + Hash + Clone,
 {
-    type State = T;
-
-    fn compile(&mut self, input: &CompilationInput<Self::State>) -> Result<Completion, Reason> {
+    fn compile(&mut self, input: &CompilationInput<State>) -> Result<Completion, Reason> {
         self._compile(input)
     }
 
@@ -260,7 +258,7 @@ where
 
     fn drain_cutset<F>(&mut self, func: F)
     where
-        F: FnMut(SubProblem<Self::State>) {
+        F: FnMut(SubProblem<State>) {
         self._drain_cutset(func)
     }
 }

--- a/ddo/src/implementation/mdd/pooled.rs
+++ b/ddo/src/implementation/mdd/pooled.rs
@@ -33,9 +33,9 @@ struct LayerId(usize);
 
 /// Represents an effective node from the decision diagram
 #[derive(Debug, Clone)]
-struct Node<T> {
+struct Node<State> {
     /// The state associated to this node
-    state: Arc<T>,
+    state: Arc<State>,
     /// The length of the longest path between the problem root and this
     /// specific node
     value_top: isize,
@@ -114,9 +114,9 @@ struct Layer {
 /// - Relaxed: either the last exact layer of the frontier cut-set can be chosen
 ///            within the CompilationInput
 #[derive(Debug, Clone)]
-pub struct Pooled<T>
+pub struct Pooled<State>
 where
-    T: Eq + PartialEq + Hash + Clone,
+    State: Eq + PartialEq + Hash + Clone,
 {
     /// This map stores the information about the structure of all the layers
     /// in this decision diagram
@@ -124,7 +124,7 @@ where
     /// All the nodes composing this decision diagram. The vector comprises 
     /// nodes from all layers in the DD. A nice property is that all nodes
     /// belonging to one same layer form a sequence in the ‘nodes‘ vector.
-    nodes: Vec<Node<T>>,
+    nodes: Vec<Node<State>>,
     /// This vector stores the information about all edges connecting the nodes 
     /// of the decision diagram.
     edges: Vec<Edge>,
@@ -139,7 +139,7 @@ where
     /// The rationale being that two transitions to the same state in the same
     /// layer should lead to the same node. This indexation helps ensuring 
     /// the uniqueness constraint in amortized O(1).
-    pool: FxHashMap<Arc<T>, NodeId>,
+    pool: FxHashMap<Arc<State>, NodeId>,
 
     /// Keeps track of the decisions that have been taken to reach the root
     /// of this DD, starting from the problem root.
@@ -212,22 +212,20 @@ macro_rules! append_edge_to {
     };
 }
 
-impl<T> Default for Pooled<T>
+impl<State> Default for Pooled<State>
 where
-    T: Eq + PartialEq + Hash + Clone,
+    State: Eq + PartialEq + Hash + Clone,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T> DecisionDiagram for Pooled<T>
+impl<State> DecisionDiagram<State> for Pooled<State>
 where
-    T: Eq + PartialEq + Hash + Clone,
+    State: Eq + PartialEq + Hash + Clone,
 {
-    type State = T;
-
-    fn compile(&mut self, input: &CompilationInput<Self::State>) -> Result<Completion, Reason> {
+    fn compile(&mut self, input: &CompilationInput<State>) -> Result<Completion, Reason> {
         self._compile(input)
     }
 
@@ -253,7 +251,7 @@ where
 
     fn drain_cutset<F>(&mut self, func: F)
     where
-        F: FnMut(SubProblem<Self::State>) {
+        F: FnMut(SubProblem<State>) {
         self._drain_cutset(func)
     }
 }

--- a/ddo/src/implementation/solver/parallel.rs
+++ b/ddo/src/implementation/solver/parallel.rs
@@ -83,7 +83,7 @@ struct Critical<'a, State> {
 /// access to the critical data (protected by a mutex) as well as a monitor
 /// (condvar) to park threads in case of node-starvation.
 struct Shared<'a, State, C> where
-    C : Cache<State = State> + Send + Sync + Default,
+    C : Cache<State> + Send + Sync + Default,
 {
     /// A reference to the problem being solved with branch-and-bound MDD
     problem: &'a (dyn Problem<State = State> + Send + Sync),
@@ -286,7 +286,7 @@ enum WorkLoad<T> {
 /// ```
 pub struct ParallelSolver<'a, State, D, C> 
 where D: DecisionDiagram<State = State> + Default,
-      C: Cache<State = State> + Send + Sync + Default,
+      C: Cache<State> + Send + Sync + Default,
 {
     /// This is the shared state. Each thread is going to take a reference to it.
     shared: Shared<'a, State, C>,
@@ -303,7 +303,7 @@ impl<'a, State, D, C>  ParallelSolver<'a, State, D, C>
 where 
     State: Eq + Hash + Clone,
     D: DecisionDiagram<State = State> + Default,
-    C: Cache<State = State> + Send + Sync + Default,
+    C: Cache<State> + Send + Sync + Default,
 {
     pub fn new(
         problem: &'a (dyn Problem<State = State> + Send + Sync),
@@ -564,7 +564,7 @@ impl<'a, State, D, C> Solver for ParallelSolver<'a, State, D, C>
 where
     State: Eq + PartialEq + Hash + Clone,
     D: DecisionDiagram<State = State> + Default,
-    C: Cache<State = State> + Send + Sync + Default,
+    C: Cache<State> + Send + Sync + Default,
 {
     /// Applies the branch and bound algorithm proposed by Bergman et al. to
     /// solve the problem to optimality. To do so, it spawns `nb_threads` workers

--- a/ddo/src/implementation/solver/parallel.rs
+++ b/ddo/src/implementation/solver/parallel.rs
@@ -101,7 +101,7 @@ struct Shared<'a, State, C> where
 
     /// Data structure containing info about past compilations used to prune the search
     cache: C,
-    dominance: &'a (dyn DominanceChecker<State = State> + Send + Sync),
+    dominance: &'a (dyn DominanceChecker<State> + Send + Sync),
 
     /// This is the shared state data which can only be accessed within critical
     /// sections. Therefore, it is protected by a mutex which prevents concurrent
@@ -310,7 +310,7 @@ where
         relaxation: &'a (dyn Relaxation<State = State> + Send + Sync),
         ranking: &'a (dyn StateRanking<State = State> + Send + Sync),
         width: &'a (dyn WidthHeuristic<State> + Send + Sync),
-        dominance: &'a (dyn DominanceChecker<State = State> + Send + Sync),
+        dominance: &'a (dyn DominanceChecker<State> + Send + Sync),
         cutoff: &'a (dyn Cutoff + Send + Sync), 
         fringe: &'a mut (dyn Fringe<State = State> + Send + Sync),
     ) -> Self {
@@ -322,7 +322,7 @@ where
         relaxation: &'a (dyn Relaxation<State = State> + Send + Sync),
         ranking: &'a (dyn StateRanking<State = State> + Send + Sync),
         width_heu: &'a (dyn WidthHeuristic<State> + Send + Sync),
-        dominance: &'a (dyn DominanceChecker<State = State> + Send + Sync),
+        dominance: &'a (dyn DominanceChecker<State> + Send + Sync),
         cutoff: &'a (dyn Cutoff + Send + Sync),
         fringe: &'a mut (dyn Fringe<State = State> + Send + Sync),
         nb_threads: usize,

--- a/ddo/src/implementation/solver/parallel.rs
+++ b/ddo/src/implementation/solver/parallel.rs
@@ -40,7 +40,7 @@ struct Critical<'a, State> {
     /// any of the nodes remaining on the fringe. As a consequence, the
     /// exploration can be stopped as soon as a node with an ub <= current best
     /// lower bound is popped.
-    fringe: &'a mut (dyn Fringe<State = State> + Send + Sync),
+    fringe: &'a mut (dyn Fringe<State> + Send + Sync),
     /// This is the number of nodes that are currently being explored.
     ///
     /// # Note
@@ -312,7 +312,7 @@ where
         width: &'a (dyn WidthHeuristic<State> + Send + Sync),
         dominance: &'a (dyn DominanceChecker<State> + Send + Sync),
         cutoff: &'a (dyn Cutoff + Send + Sync), 
-        fringe: &'a mut (dyn Fringe<State = State> + Send + Sync),
+        fringe: &'a mut (dyn Fringe<State> + Send + Sync),
     ) -> Self {
         Self::custom(problem, relaxation, ranking, width, dominance, cutoff, fringe, num_cpus::get())
     }
@@ -324,7 +324,7 @@ where
         width_heu: &'a (dyn WidthHeuristic<State> + Send + Sync),
         dominance: &'a (dyn DominanceChecker<State> + Send + Sync),
         cutoff: &'a (dyn Cutoff + Send + Sync),
-        fringe: &'a mut (dyn Fringe<State = State> + Send + Sync),
+        fringe: &'a mut (dyn Fringe<State> + Send + Sync),
         nb_threads: usize,
     ) -> Self {
         ParallelSolver {

--- a/ddo/src/implementation/solver/parallel.rs
+++ b/ddo/src/implementation/solver/parallel.rs
@@ -285,7 +285,7 @@ enum WorkLoad<T> {
 /// }
 /// ```
 pub struct ParallelSolver<'a, State, D, C> 
-where D: DecisionDiagram<State = State> + Default,
+where D: DecisionDiagram<State> + Default,
       C: Cache<State> + Send + Sync + Default,
 {
     /// This is the shared state. Each thread is going to take a reference to it.
@@ -302,7 +302,7 @@ where D: DecisionDiagram<State = State> + Default,
 impl<'a, State, D, C>  ParallelSolver<'a, State, D, C>
 where 
     State: Eq + Hash + Clone,
-    D: DecisionDiagram<State = State> + Default,
+    D: DecisionDiagram<State> + Default,
     C: Cache<State> + Send + Sync + Default,
 {
     pub fn new(
@@ -563,7 +563,7 @@ where
 impl<'a, State, D, C> Solver for ParallelSolver<'a, State, D, C>
 where
     State: Eq + PartialEq + Hash + Clone,
-    D: DecisionDiagram<State = State> + Default,
+    D: DecisionDiagram<State> + Default,
     C: Cache<State> + Send + Sync + Default,
 {
     /// Applies the branch and bound algorithm proposed by Bergman et al. to

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -200,7 +200,7 @@ enum WorkLoad<T> {
 /// }
 /// ```
 pub struct SequentialSolver<'a, State, D = DefaultMDDLEL<State>, C = EmptyCache<State>> 
-where D: DecisionDiagram<State = State> + Default,
+where D: DecisionDiagram<State> + Default,
       C: Cache<State> + Default,
 {
     /// A reference to the problem being solved with branch-and-bound MDD
@@ -257,7 +257,7 @@ where D: DecisionDiagram<State = State> + Default,
 impl<'a, State, D, C>  SequentialSolver<'a, State, D, C>
 where 
     State: Eq + Hash + Clone,
-    D: DecisionDiagram<State = State> + Default,
+    D: DecisionDiagram<State> + Default,
     C: Cache<State> + Default,
 {
     pub fn new(
@@ -465,7 +465,7 @@ where
 impl<'a, State, D, C> Solver for SequentialSolver<'a, State, D, C>
 where
     State: Eq + PartialEq + Hash + Clone,
-    D: DecisionDiagram<State = State> + Default,
+    D: DecisionDiagram<State> + Default,
     C: Cache<State> + Default,
 {
     /// Applies the branch and bound algorithm proposed by Bergman et al. to

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -201,7 +201,7 @@ enum WorkLoad<T> {
 /// ```
 pub struct SequentialSolver<'a, State, D = DefaultMDDLEL<State>, C = EmptyCache<State>> 
 where D: DecisionDiagram<State = State> + Default,
-      C: Cache<State = State> + Default,
+      C: Cache<State> + Default,
 {
     /// A reference to the problem being solved with branch-and-bound MDD
     problem: &'a (dyn Problem<State = State>),
@@ -258,7 +258,7 @@ impl<'a, State, D, C>  SequentialSolver<'a, State, D, C>
 where 
     State: Eq + Hash + Clone,
     D: DecisionDiagram<State = State> + Default,
-    C: Cache<State = State> + Default,
+    C: Cache<State> + Default,
 {
     pub fn new(
         problem: &'a (dyn Problem<State = State>),
@@ -466,7 +466,7 @@ impl<'a, State, D, C> Solver for SequentialSolver<'a, State, D, C>
 where
     State: Eq + PartialEq + Hash + Clone,
     D: DecisionDiagram<State = State> + Default,
-    C: Cache<State = State> + Default,
+    C: Cache<State> + Default,
 {
     /// Applies the branch and bound algorithm proposed by Bergman et al. to
     /// solve the problem to optimality. To do so, it spawns `nb_threads` workers

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -251,7 +251,7 @@ where D: DecisionDiagram<State = State> + Default,
     mdd: D,
     /// Data structure containing info about past compilations used to prune the search
     cache: C,
-    dominance: &'a (dyn DominanceChecker<State = State>),
+    dominance: &'a (dyn DominanceChecker<State>),
 }
 
 impl<'a, State, D, C>  SequentialSolver<'a, State, D, C>
@@ -265,7 +265,7 @@ where
         relaxation: &'a (dyn Relaxation<State = State>),
         ranking: &'a (dyn StateRanking<State = State>),
         width: &'a (dyn WidthHeuristic<State>),
-        dominance: &'a (dyn DominanceChecker<State = State>),
+        dominance: &'a (dyn DominanceChecker<State>),
         cutoff: &'a (dyn Cutoff), 
         fringe: &'a mut (dyn Fringe<State = State>),
     ) -> Self {
@@ -277,7 +277,7 @@ where
         relaxation: &'a (dyn Relaxation<State = State>),
         ranking: &'a (dyn StateRanking<State = State>),
         width_heu: &'a (dyn WidthHeuristic<State>),
-        dominance: &'a (dyn DominanceChecker<State = State>),
+        dominance: &'a (dyn DominanceChecker<State>),
         cutoff: &'a (dyn Cutoff),
         fringe: &'a mut (dyn Fringe<State = State>),
     ) -> Self {

--- a/ddo/src/implementation/solver/sequential.rs
+++ b/ddo/src/implementation/solver/sequential.rs
@@ -227,7 +227,7 @@ where D: DecisionDiagram<State = State> + Default,
     /// any of the nodes remaining on the fringe. As a consequence, the
     /// exploration can be stopped as soon as a node with an ub <= current best
     /// lower bound is popped.
-    fringe: &'a mut (dyn Fringe<State = State>),
+    fringe: &'a mut (dyn Fringe<State>),
     /// This is a counter that tracks the number of nodes that have effectively
     /// been explored. That is, the number of nodes that have been popped from
     /// the fringe, and for which a restricted and relaxed mdd have been developed.
@@ -267,7 +267,7 @@ where
         width: &'a (dyn WidthHeuristic<State>),
         dominance: &'a (dyn DominanceChecker<State>),
         cutoff: &'a (dyn Cutoff), 
-        fringe: &'a mut (dyn Fringe<State = State>),
+        fringe: &'a mut (dyn Fringe<State>),
     ) -> Self {
         Self::custom(problem, relaxation, ranking, width, dominance, cutoff, fringe)
     }
@@ -279,7 +279,7 @@ where
         width_heu: &'a (dyn WidthHeuristic<State>),
         dominance: &'a (dyn DominanceChecker<State>),
         cutoff: &'a (dyn Cutoff),
-        fringe: &'a mut (dyn Fringe<State = State>),
+        fringe: &'a mut (dyn Fringe<State>),
     ) -> Self {
         SequentialSolver {
             problem,


### PR DESCRIPTION
Guessing from the [technical note](https://github.com/xgillard/ddo/blob/06912f8565281ac58d462386e87f8e5fedcd1690/ddo/src/abstraction/heuristics.rs#L36) for `WidthHeuristic`, all traits that don't directly define the problem are designed to be problem-agnostic, and should be written using type parameters instead of associated types.

This PR changes the traits `DecisionDiagram`, `Fringe`, `Cache`, `DominanceChecker`, and `SubProblemRanking` to use type parameters instead of associated types. The former three are obviously part of the "engine"; the other two act as wrappers for user-implemented traits `Dominance` and `StateRanking` respectively, and therefore can be considered problem-agnostic as well. All examples compiled and example tests passed without modification.

I'm working on generalizing `Solution` to allow types other than `Vec<Decision>`, including

* a linked list of chunks of `Decisions`, to avoid duplication
* a user-supplied type, e.g. a bitset if the problem involves binary variables and the variables are visited in a fixed order

and this PR is expected to make the change a bit cleaner.